### PR TITLE
Update requirements, bump version of GOB-Core

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,9 +1,11 @@
 atomicwrites==1.2.1
 attrs==18.2.0
+click==6.7
 coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.2#egg=gobcore
+geomet==0.2.0.post2
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.3#egg=gobcore
 mccabe==0.6.1
 more-itertools==4.3.0
 numpy==1.15.1


### PR DESCRIPTION
New version of GOB-Core was needed for the generation of entity tables
and events, because of the use of GOB.DateTime