### PR TITLE
Initialize database tables on boot

### DIFF
--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,1 +1,2 @@
 */__pycache__/
+*.pyc

--- a/src/gobuploadservice/__main__.py
+++ b/src/gobuploadservice/__main__.py
@@ -8,6 +8,7 @@ It writes the storage to apply events to the storage
 from gobcore.message_broker.messagedriven_service import messagedriven_service
 from gobuploadservice import compare
 from gobuploadservice import update
+from gobuploadservice.storage.handler import GOBStorageHandler
 
 SERVICEDEFINITION = {
     'fullimport.request': {
@@ -23,5 +24,8 @@ SERVICEDEFINITION = {
         'report_queue': 'gob.workflow.proposal'
     },
 }
+
+# Initialize database tables
+storage = GOBStorageHandler()
 
 messagedriven_service(SERVICEDEFINITION)

--- a/src/gobuploadservice/compare.py
+++ b/src/gobuploadservice/compare.py
@@ -7,6 +7,7 @@ Todo: Event, action and mutation are used for the same subject. Use one name to 
 """
 from gobcore.events import get_event_for
 from gobcore.events.import_message import ImportMessage
+from gobcore.model import GOBModel
 from gobcore.typesystem import get_modifications
 
 from gobuploadservice import print_report
@@ -23,6 +24,9 @@ def compare(msg):
     # Parse the message header
     message = ImportMessage(msg)
     metadata = message.metadata
+
+    gob_model = GOBModel()
+    entity_model = gob_model.get_model(metadata.entity)
 
     # Read new content into dictionary
     new_entities = {data['_source_id']: data for data in msg["contents"]}
@@ -45,7 +49,7 @@ def compare(msg):
             entity = storage.get_entity_or_none(entity_id)
             # calculate modifications, this will be an empty list if either data or entity is empty
             # or if all attributes are equal
-            modifications = get_modifications(entity, data, metadata.model)
+            modifications = get_modifications(entity, data, entity_model['fields'])
             # construct the event given the entity, data, and metadata
             event = get_event_for(entity, data, metadata, modifications)
             # append the event to the events-list to be outputted

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,7 +5,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.6#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.2.11#egg=gobcore
 mccabe==0.6.1
 more-itertools==4.3.0
 numpy==1.15.1

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -56,7 +56,9 @@ def get_event_fixture(metadata, event_name=None):
 
 
 def get_metadata_fixture():
-    header = {key: random_string() for key in ["source", "timestamp", "id_column", "entity", "version"]}
+    header = {key: random_string() for key in ["source", "timestamp", "version"]}
+    header["entity"] = "meetbouten"
+    header["id_column"] = "meetboutid"
     header["model"] = {header['id_column']: {"type": "GOB.String"}}
     return MessageMetaData(**header).as_header
 

--- a/src/tests/test_compare.py
+++ b/src/tests/test_compare.py
@@ -1,18 +1,21 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from gobcore.model import GOBModel
 from gobuploadservice.compare import compare
 from gobuploadservice.storage.handler import GOBStorageHandler
 from tests import fixtures
 
 
+@patch('gobuploadservice.compare.GOBModel')
 @patch('gobuploadservice.compare.GOBStorageHandler')
 class TestCompare(TestCase):
     def setUp(self):
-        self.mock_storage =  MagicMock(spec=GOBStorageHandler)
+        self.mock_storage = MagicMock(spec=GOBStorageHandler)
+        self.mock_model = MagicMock(spec=GOBModel)
 
-    def test_compare_creates_delete(self, mock):
-        mock.return_value = self.mock_storage
+    def test_compare_creates_delete(self, storage_mock, model_mock):
+        storage_mock.return_value = self.mock_storage
 
         # setup: one entity in db, none in message
         self.mock_storage.get_current_ids.return_value = [fixtures.get_entity_fixture(_source_id=1)]
@@ -24,8 +27,8 @@ class TestCompare(TestCase):
         self.assertEqual(len(result['contents']), 1)
         self.assertEqual(result['contents'][0]['event'], 'DELETE')
 
-    def test_compare_creates_add(self, mock):
-        mock.return_value = self.mock_storage
+    def test_compare_creates_add(self, storage_mock, model_mock):
+        storage_mock.return_value = self.mock_storage
 
         # setup: no entity in db, one in message
         self.mock_storage.get_entity_or_none.return_value = None
@@ -37,8 +40,8 @@ class TestCompare(TestCase):
         self.assertEqual(len(result['contents']), 1)
         self.assertEqual(result['contents'][0]['event'], 'ADD')
 
-    def test_compare_creates_confirm(self, mock):
-        mock.return_value = self.mock_storage
+    def test_compare_creates_confirm(self, storage_mock, model_mock):
+        storage_mock.return_value = self.mock_storage
 
         # setup: message and database have the same entity
         message = fixtures.get_message_fixture()
@@ -55,8 +58,9 @@ class TestCompare(TestCase):
         self.assertEqual(len(result['contents']), 1)
         self.assertEqual(result['contents'][0]['event'], 'CONFIRM')
 
-    def test_compare_creates_modify(self, mock):
-        mock.return_value = self.mock_storage
+    def test_compare_creates_modify(self, storage_mock, model_mock):
+        storage_mock.return_value = self.mock_storage
+        model_mock.return_value = self.mock_model
 
         # setup: message and database have entity with same id but different data
         field_name = fixtures.random_string()
@@ -72,6 +76,15 @@ class TestCompare(TestCase):
 
         self.mock_storage.get_current_ids.return_value = [entity]
         self.mock_storage.get_entity_or_none.return_value = entity
+
+        # Add the field to the model as well
+        self.mock_model.get_model.return_value = {
+            "fields": {
+                field_name: {
+                    "type": "GOB.String"
+                }
+            }
+        }
 
         result = compare(message)
 

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -2,14 +2,16 @@ from unittest import TestCase, mock
 
 
 class TestMain(TestCase):
+    @mock.patch('gobuploadservice.storage.handler.GOBStorageHandler')
     @mock.patch('gobcore.message_broker.messagedriven_service.messagedriven_service')
-    def test_main_calls_service_with_definition(self, mock_service):
+    def test_main_calls_service_with_definition(self, mock_service, mock_storage):
         from gobuploadservice import __main__
         mock_service.assert_called_with(__main__.SERVICEDEFINITION)
 
     # Mock this, to prevent service from starting when importing __main__
+    @mock.patch('gobuploadservice.storage.handler.GOBStorageHandler')
     @mock.patch('gobcore.message_broker.messagedriven_service.messagedriven_service')
-    def test_servicedefenition(self, mock_service):
+    def test_servicedefenition(self, mock_service, mock_storage):
         from gobuploadservice import __main__
 
         for key, definition in __main__.SERVICEDEFINITION.items():


### PR DESCRIPTION
Tables are now being generated on boot based on the gobcore model. The model is also used instead of metadata when comparing and updating the records.