### PR TITLE
Added storage scripts

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -39,11 +39,10 @@ SERVICEDEFINITION = {
     },
 }
 
-print("START STORAGE")
 
 # Initialize database tables
 storage = GOBStorageHandler()
+storage.init_storage()
 
-print("START MESSAGE BROKER")
 
 messagedriven_service(SERVICEDEFINITION)

--- a/src/gobupload/storage/__main__.py
+++ b/src/gobupload/storage/__main__.py
@@ -1,0 +1,50 @@
+"""Storage commands
+
+This command line script can be used to clear the database or truncate the
+tables. For now this is intented to reduce the manual steps needed when
+changing models or other database tables.
+
+     python -m gobupload.storage drop <table> or --all
+     python -m gobupload.storage truncate <table> or --all
+     python -m gobupload.storage init
+"""
+import argparse
+
+from gobupload.storage.handler import GOBStorageHandler
+
+
+parser = argparse.ArgumentParser(
+    prog='python -m gobupload.storage',
+    description='Perform database mutations',
+    epilog='Generieke Ontsluiting Basisregistraties')
+
+parser.add_argument('command',
+                    type=str,
+                    help='the command to perform on the database')
+
+parser.add_argument('table',
+                    nargs='?',
+                    type=str,
+                    help='the specific table to perform the command on')
+
+parser.add_argument('--all',
+                    action='store_true',
+                    help='flag to perform the command on all tables')
+
+args = parser.parse_args()
+
+# Return an error if no table or --all is provided when dropping or truncating a table
+if args.command in ('drop', 'truncate') and not args.table and not args.all:
+    parser.error('a table or --all is required when trying to drop or truncate')
+
+storage = GOBStorageHandler()
+tables = [args.table] if not args.all else storage.ALL_TABLES
+
+if args.command == 'drop':
+    storage.drop_tables(tables)
+
+if args.command == 'truncate':
+    storage.truncate_tables(tables)
+
+if args.command == 'init':
+    storage.init_storage()

--- a/src/gobupload/storage/__main__.py
+++ b/src/gobupload/storage/__main__.py
@@ -4,9 +4,7 @@ This command line script can be used to clear the database or truncate the
 tables. For now this is intented to reduce the manual steps needed when
 changing models or other database tables.
 
-     python -m gobupload.storage drop <table> or --all
-     python -m gobupload.storage truncate <table> or --all
-     python -m gobupload.storage init
+     python -m gobupload.storage resetdb
 """
 import argparse
 import getpass

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -161,20 +161,14 @@ class GOBStorageHandler():
         return getattr(self.base.classes, self.metadata.entity)
 
     def _drop_table(self, table):
-        statement = f"DROP TABLE {table} CASCADE"
+        statement = f"DROP TABLE IF EXISTS {table} CASCADE"
         self.engine.execute(statement)
 
-    def drop_tables(self, tables):
+    def drop_tables(self):
         for table in self.ALL_TABLES:
             self._drop_table(table)
-
-    def _truncate_table(self, table):
-        statement = f"TRUNCATE TABLE {table}"
-        self.engine.execute(statement)
-
-    def truncate_tables(self, tables):
-        for table in tables:
-            self._truncate_table(table)
+        # Update the reflected base
+        self._get_reflected_base()
 
     def get_session(self):
         """ Exposes an underlying database session as managed context """


### PR DESCRIPTION
Scripts were added to be able to quickly truncate, drop or initialize the database or a single table. They can be started with:

python -m gobupload.storage drop <table>
python -m gobupload.storage drop --all
python -m gobupload.storage truncate <table>
python -m gobupload.storage truncate --all
python -m gobupload.storage init