### PR TITLE
Reenable logging

### DIFF
--- a/src/gobupload/compare.py
+++ b/src/gobupload/compare.py
@@ -15,15 +15,13 @@ from gobupload import get_report
 from gobupload.storage.handler import GOBStorageHandler
 
 
-logger = get_logger(name="COMPARE")
-
-
 def compare(msg):
     """Compare new data in msg (contents) with the current data
 
     :param msg: The new data, including header and summary
     :return: result message
     """
+    logger = get_logger(name="COMPARE")
 
     extra_log_kwargs = {
         'process_id': msg['header']['process_id'],

--- a/src/gobupload/update.py
+++ b/src/gobupload/update.py
@@ -15,17 +15,16 @@ logger = None
 
 class Logger():
 
-    _logger = get_logger("UPDATE")
-
     def __init__(self, name, default_args):
         self._name = name
         self._default_args = default_args
+        self._logger = get_logger("UPDATE")
 
     def info(self, msg, kwargs={}):
-        Logger._logger.info(msg, extra={**(self._default_args), **kwargs})
+        self._logger.info(msg, extra={**(self._default_args), **kwargs})
 
     def warning(self, msg, kwargs={}):
-        Logger._logger.warning(msg, extra={**(self._default_args), **kwargs})
+        self._logger.warning(msg, extra={**(self._default_args), **kwargs})
 
 
 def _get_gob_event(event, data):


### PR DESCRIPTION
Alembic changes the default logging level

Declare the loggers in the compare and update methods re-enables
logging