### PR TITLE
Change all JSON columns to JSONB

### DIFF
--- a/src/alembic/versions/29149a285ff2_change_json_to_jsonb.py
+++ b/src/alembic/versions/29149a285ff2_change_json_to_jsonb.py
@@ -1,0 +1,88 @@
+"""Change JSON to JSONB
+
+Revision ID: 29149a285ff2
+Revises: 50a4daeb9e88
+Create Date: 2019-01-16 10:45:25.691701
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '29149a285ff2'
+down_revision = '50a4daeb9e88'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop views to allow columns to be changed, GOB-Upload will recreate them
+    op.execute('drop view meetbouten_meetbouten_enhanced')
+    op.execute('drop view meetbouten_metingen_enhanced')
+    op.execute('drop view meetbouten_referentiepunten_enhanced')
+    op.execute('drop view meetbouten_rollagen_enhanced')
+    op.execute('drop view nap_peilmerken_enhanced')
+
+    # Change all JSON columns to JSONB
+    op.alter_column('meetbouten_meetbouten', 'nabij_nummeraanduiding', type_=postgresql.JSONB, postgresql_using='nabij_nummeraanduiding::text::jsonb')
+    op.alter_column('meetbouten_meetbouten', 'status', type_=postgresql.JSONB, postgresql_using='status::text::jsonb')
+    op.alter_column('meetbouten_meetbouten', 'merk', type_=postgresql.JSONB, postgresql_using='merk::text::jsonb')
+    op.alter_column('meetbouten_meetbouten', 'ligt_in_bouwblok', type_=postgresql.JSONB, postgresql_using='ligt_in_bouwblok::text::jsonb')
+    op.alter_column('meetbouten_meetbouten', 'ligt_in_buurt', type_=postgresql.JSONB, postgresql_using='ligt_in_buurt::text::jsonb')
+    op.alter_column('meetbouten_meetbouten', 'ligt_in_stadsdeel', type_=postgresql.JSONB, postgresql_using='ligt_in_stadsdeel::text::jsonb')
+
+    op.alter_column('meetbouten_metingen', 'hoort_bij_meetbout', type_=postgresql.JSONB, postgresql_using='hoort_bij_meetbout::text::jsonb')
+    op.alter_column('meetbouten_metingen', 'wijze_van_inwinnen', type_=postgresql.JSONB, postgresql_using='wijze_van_inwinnen::text::jsonb')
+    op.alter_column('meetbouten_metingen', 'refereert_aan', type_=postgresql.JSONB, postgresql_using='refereert_aan::text::jsonb')
+
+    op.alter_column('meetbouten_referentiepunten', 'nabij_nummeraanduiding', type_=postgresql.JSONB, postgresql_using='nabij_nummeraanduiding::text::jsonb')
+    op.alter_column('meetbouten_referentiepunten', 'status', type_=postgresql.JSONB, postgresql_using='status::text::jsonb')
+    op.alter_column('meetbouten_referentiepunten', 'merk', type_=postgresql.JSONB, postgresql_using='merk::text::jsonb')
+    op.alter_column('meetbouten_referentiepunten', 'ligt_in_bouwblok', type_=postgresql.JSONB, postgresql_using='ligt_in_bouwblok::text::jsonb')
+    op.alter_column('meetbouten_referentiepunten', 'ligt_in_buurt', type_=postgresql.JSONB, postgresql_using='ligt_in_buurt::text::jsonb')
+    op.alter_column('meetbouten_referentiepunten', 'ligt_in_stadsdeel', type_=postgresql.JSONB, postgresql_using='ligt_in_stadsdeel::text::jsonb')
+    op.alter_column('meetbouten_referentiepunten', 'is_nap_peilmerk', type_=postgresql.JSONB, postgresql_using='is_nap_peilmerk::text::jsonb')
+
+    op.alter_column('meetbouten_rollagen', 'is_gemeten_van_bouwblok', type_=postgresql.JSONB, postgresql_using='is_gemeten_van_bouwblok::text::jsonb')
+
+    op.alter_column('nap_peilmerken', 'merk', type_=postgresql.JSONB, postgresql_using='merk::text::jsonb')
+    op.alter_column('nap_peilmerken', 'status', type_=postgresql.JSONB, postgresql_using='status::text::jsonb')
+    op.alter_column('nap_peilmerken', 'ligt_in_bouwblok', type_=postgresql.JSONB, postgresql_using='ligt_in_bouwblok::text::jsonb')
+
+
+def downgrade():
+    # Drop views to allow columns to be changed, GOB-Upload will recreate them
+    op.execute('drop view meetbouten_meetbouten_enhanced')
+    op.execute('drop view meetbouten_metingen_enhanced')
+    op.execute('drop view meetbouten_referentiepunten_enhanced')
+    op.execute('drop view meetbouten_rollagen_enhanced')
+    op.execute('drop view nap_peilmerken_enhanced')
+
+    # Change all JSONB columns to JSON
+    op.alter_column('meetbouten_meetbouten', 'nabij_nummeraanduiding', type_=postgresql.JSONB, postgresql_using='nabij_nummeraanduiding::text::json')
+    op.alter_column('meetbouten_meetbouten', 'status', type_=postgresql.JSONB, postgresql_using='status::text::json')
+    op.alter_column('meetbouten_meetbouten', 'merk', type_=postgresql.JSONB, postgresql_using='merk::text::json')
+    op.alter_column('meetbouten_meetbouten', 'ligt_in_bouwblok', type_=postgresql.JSONB, postgresql_using='ligt_in_bouwblok::text::json')
+    op.alter_column('meetbouten_meetbouten', 'ligt_in_buurt', type_=postgresql.JSONB, postgresql_using='ligt_in_buurt::text::json')
+    op.alter_column('meetbouten_meetbouten', 'ligt_in_stadsdeel', type_=postgresql.JSONB, postgresql_using='ligt_in_stadsdeel::text::json')
+
+    op.alter_column('meetbouten_metingen', 'hoort_bij_meetbout', type_=postgresql.JSONB, postgresql_using='hoort_bij_meetbout::text::json')
+    op.alter_column('meetbouten_metingen', 'wijze_van_inwinnen', type_=postgresql.JSONB, postgresql_using='wijze_van_inwinnen::text::json')
+    op.alter_column('meetbouten_metingen', 'refereert_aan', type_=postgresql.JSONB, postgresql_using='refereert_aan::text::json')
+
+    op.alter_column('meetbouten_referentiepunten', 'nabij_nummeraanduiding', type_=postgresql.JSONB, postgresql_using='nabij_nummeraanduiding::text::json')
+    op.alter_column('meetbouten_referentiepunten', 'status', type_=postgresql.JSONB, postgresql_using='status::text::json')
+    op.alter_column('meetbouten_referentiepunten', 'merk', type_=postgresql.JSONB, postgresql_using='merk::text::json')
+    op.alter_column('meetbouten_referentiepunten', 'ligt_in_bouwblok', type_=postgresql.JSONB, postgresql_using='ligt_in_bouwblok::text::json')
+    op.alter_column('meetbouten_referentiepunten', 'ligt_in_buurt', type_=postgresql.JSONB, postgresql_using='ligt_in_buurt::text::json')
+    op.alter_column('meetbouten_referentiepunten', 'ligt_in_stadsdeel', type_=postgresql.JSONB, postgresql_using='ligt_in_stadsdeel::text::json')
+    op.alter_column('meetbouten_referentiepunten', 'is_nap_peilmerk', type_=postgresql.JSONB, postgresql_using='is_nap_peilmerk::text::json')
+
+    op.alter_column('meetbouten_rollagen', 'is_gemeten_van_bouwblok', type_=postgresql.JSONB, postgresql_using='is_gemeten_van_bouwblok::text::json')
+
+    op.alter_column('nap_peilmerken', 'merk', type_=postgresql.JSONB, postgresql_using='merk::text::json')
+    op.alter_column('nap_peilmerken', 'status', type_=postgresql.JSONB, postgresql_using='status::text::json')
+    op.alter_column('nap_peilmerken', 'ligt_in_bouwblok', type_=postgresql.JSONB, postgresql_using='ligt_in_bouwblok::text::json')

--- a/src/gobupload/relations.py
+++ b/src/gobupload/relations.py
@@ -87,7 +87,7 @@ def _get_all_entities(update_model, relation):
             getattr(update_model, relation['field_name'])['bronwaarde'].astext.isnot(None)
         )
     elif relation['type'] == 'GOB.ManyReference':
-        # Get all entities where the value is an empty array
+        # Get all entities where the value is not an empty array
         return storage.session.query(update_model).filter(
             cast(getattr(update_model, relation['field_name']), Text) != '[]'
         )
@@ -120,7 +120,7 @@ SET {relation['field_name']} = enhanced.related
 FROM (
     SELECT {update_table}._id, jsonb_agg(value::JSONB ||
                                ('{{\"id\": \"'|| {source_table}._id ||'\"}}')::JSONB) as related
-    FROM {update_table}, json_array_elements({update_table}.{relation['field_name']})
+    FROM {update_table}, jsonb_array_elements({update_table}.{relation['field_name']})
     LEFT JOIN {source_table}
     ON value->>'bronwaarde' = {source_table}.{relation['destination_attribute']}
     GROUP BY {update_table}._id

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.32#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.33#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/tests/test_relations.py
+++ b/src/tests/test_relations.py
@@ -137,7 +137,7 @@ SET field_name = enhanced.related
 FROM (
     SELECT catalog2_collection2._id, jsonb_agg(value::JSONB ||
                                ('{"id": "'|| catalog_collection._id ||'"}')::JSONB) as related
-    FROM catalog2_collection2, json_array_elements(catalog2_collection2.field_name)
+    FROM catalog2_collection2, jsonb_array_elements(catalog2_collection2.field_name)
     LEFT JOIN catalog_collection
     ON value->>'bronwaarde' = catalog_collection.identificatie
     GROUP BY catalog2_collection2._id


### PR DESCRIPTION
We’ve switched to JSONB in the postgres database, but previously generated tables were still using JSON. This resulted in an error while trying to build relations on ManyReference fields. This alembic migration will change all columns to JSONB and updates the code to work for all relations. Views are dropped before the migration, but GOB-Upload recreates them on boot