### PR TITLE
Add state to ManyReferences

### DIFF
--- a/src/alembic/versions/29149a285ff2_change_json_to_jsonb.py
+++ b/src/alembic/versions/29149a285ff2_change_json_to_jsonb.py
@@ -20,11 +20,11 @@ depends_on = None
 
 def upgrade():
     # Drop views to allow columns to be changed, GOB-Upload will recreate them
-    op.execute('drop view meetbouten_meetbouten_enhanced')
-    op.execute('drop view meetbouten_metingen_enhanced')
-    op.execute('drop view meetbouten_referentiepunten_enhanced')
-    op.execute('drop view meetbouten_rollagen_enhanced')
-    op.execute('drop view nap_peilmerken_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_meetbouten_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_metingen_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_referentiepunten_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_rollagen_enhanced')
+    op.execute('DROP VIEW IF EXISTS nap_peilmerken_enhanced')
 
     # Change all JSON columns to JSONB
     op.alter_column('meetbouten_meetbouten', 'nabij_nummeraanduiding', type_=postgresql.JSONB, postgresql_using='nabij_nummeraanduiding::text::jsonb')
@@ -55,11 +55,11 @@ def upgrade():
 
 def downgrade():
     # Drop views to allow columns to be changed, GOB-Upload will recreate them
-    op.execute('drop view meetbouten_meetbouten_enhanced')
-    op.execute('drop view meetbouten_metingen_enhanced')
-    op.execute('drop view meetbouten_referentiepunten_enhanced')
-    op.execute('drop view meetbouten_rollagen_enhanced')
-    op.execute('drop view nap_peilmerken_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_meetbouten_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_metingen_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_referentiepunten_enhanced')
+    op.execute('DROP VIEW IF EXISTS meetbouten_rollagen_enhanced')
+    op.execute('DROP VIEW IF EXISTS nap_peilmerken_enhanced')
 
     # Change all JSONB columns to JSON
     op.alter_column('meetbouten_meetbouten', 'nabij_nummeraanduiding', type_=postgresql.JSONB, postgresql_using='nabij_nummeraanduiding::text::json')


### PR DESCRIPTION
ManyReferences with state did not relate properly because multiple records were returned. Now datum_einde_geldigheid is taken into account to make sure only the latest relation is made.

Also a small change was made to the migration to JSONB. Dropping views gave an error on an empty database so 'IF EXISTS' was added to fix this