### PR TITLE
Renames to match latest specs

### DIFF
--- a/src/alembic/versions/9f515dab1ffb_rename_attributes_to_match_specs.py
+++ b/src/alembic/versions/9f515dab1ffb_rename_attributes_to_match_specs.py
@@ -1,0 +1,72 @@
+"""Rename attributes to match specs
+
+Revision ID: 9f515dab1ffb
+Revises: 29149a285ff2
+Create Date: 2019-01-17 12:53:12.962528
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '9f515dab1ffb'
+down_revision = 'bc7e206f1c45'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Rename columns to match specs
+    op.alter_column('meetbouten_metingen', 'refereert_aan', new_column_name='refereert_aan_referentiepunten')
+
+    op.alter_column('gebieden_bouwblokken', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('gebieden_bouwblokken', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+
+    op.alter_column('gebieden_buurten', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('gebieden_buurten', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+
+    op.alter_column('gebieden_wijken', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('gebieden_wijken', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+
+    op.alter_column('gebieden_ggwgebieden', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('gebieden_ggwgebieden', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+    op.alter_column('gebieden_ggwgebieden', 'bestaat_uit_wijken', new_column_name='bestaat_uit_buurten')
+
+    op.alter_column('gebieden_ggpgebieden', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('gebieden_ggpgebieden', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+
+    op.alter_column('gebieden_stadsdelen', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('gebieden_stadsdelen', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+
+    op.alter_column('bag_woonplaatsen', 'datum_begin_geldigheid', new_column_name='begin_geldigheid')
+    op.alter_column('bag_woonplaatsen', 'datum_einde_geldigheid', new_column_name='eind_geldigheid')
+
+
+
+def downgrade():
+    # Rename columns
+    op.alter_column('meetbouten_metingen', 'refereert_aan_referentiepunten', new_column_name='refereert_aan')
+
+    op.alter_column('gebieden_bouwblokken', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('gebieden_bouwblokken', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')
+
+    op.alter_column('gebieden_buurten', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('gebieden_buurten', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')
+
+    op.alter_column('gebieden_wijken', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('gebieden_wijken', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')
+
+    op.alter_column('gebieden_ggwgebieden', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('gebieden_ggwgebieden', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')
+    op.alter_column('gebieden_ggwgebieden', 'bestaat_uit_buurten', new_column_name='bestaat_uit_wijken')
+
+    op.alter_column('gebieden_ggpgebieden', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('gebieden_ggpgebieden', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')
+
+    op.alter_column('gebieden_stadsdelen', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('gebieden_stadsdelen', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')
+
+    op.alter_column('bag_woonplaatsen', 'begin_geldigheid', new_column_name='datum_begin_geldigheid')
+    op.alter_column('bag_woonplaatsen', 'eind_geldigheid', new_column_name='datum_einde_geldigheid')

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -272,7 +272,7 @@ class GOBStorageHandler():
         An entity to retrieve is evaluated within a source
         on the basis of its functional id (_id)
 
-        If the collection has states (has_states) then the datum_begin_geldigheid needs
+        If the collection has states (has_states) then the begin_geldigheid needs
         also to be considered
 
         :param entity: the new version of the entity
@@ -285,7 +285,7 @@ class GOBStorageHandler():
             collection["entity_id"]: entity[collection["entity_id"]]
         }
         if collection.get("has_states", False):
-            filter["datum_begin_geldigheid"] = entity["datum_begin_geldigheid"]
+            filter["begin_geldigheid"] = entity["begin_geldigheid"]
 
         entity_query = self.session.query(self.DbEntity).filter_by(**filter)
         if not with_deleted:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.37#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.38b#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/tests/test_relations.py
+++ b/src/tests/test_relations.py
@@ -91,7 +91,7 @@ class TestRelations(TestCase):
         expected_query = f"""
 UPDATE catalog2_collection2
 SET field_name = field_name::JSONB ||
-                               ('{{\"id\": \"'|| catalog_collection._id ||'\"}}')::JSONB
+                               ('{{\"identificatie\": \"'|| catalog_collection._id ||'\"}}')::JSONB
 FROM catalog_collection
 WHERE field_name->>'bronwaarde' = catalog_collection.identificatie
 AND catalog2_collection2._application = 'source'
@@ -120,7 +120,7 @@ AND catalog2_collection2._application = 'source'
         expected_query = f"""
 UPDATE catalog2_collection2
 SET field_name = field_name::JSONB ||
-                               ('{{\"id\": \"'|| catalog_collection._id ||'\"}}')::JSONB
+                               ('{{\"identificatie\": \"'|| catalog_collection._id ||'\"}}')::JSONB
 FROM catalog_collection
 WHERE field_name->>'bronwaarde' = catalog_collection.identificatie
 AND catalog2_collection2._application = 'source'
@@ -138,7 +138,7 @@ UPDATE catalog2_collection2
 SET field_name = enhanced.related
 FROM (
     SELECT catalog2_collection2._id, jsonb_agg(value::JSONB ||
-                               ('{"id": "'|| catalog_collection._id ||'"}')::JSONB) as related
+                               ('{"identificatie": "'|| catalog_collection._id ||'"}')::JSONB) as related
     FROM catalog2_collection2, jsonb_array_elements(catalog2_collection2.field_name)
     LEFT JOIN catalog_collection
     ON value->>'bronwaarde' = catalog_collection.identificatie
@@ -159,12 +159,12 @@ UPDATE catalog2_collection2
 SET field_name = enhanced.related
 FROM (
     SELECT catalog2_collection2._id, jsonb_agg(value::JSONB ||
-                               ('{"id": "'|| sub._id ||'"}')::JSONB) as related
+                               ('{"identificatie": "'|| sub._id ||'"}')::JSONB) as related
     FROM catalog2_collection2, jsonb_array_elements(catalog2_collection2.field_name)
     LEFT JOIN (
         SELECT _id, identificatie
         FROM catalog_collection
-        WHERE datum_einde_geldigheid IS NULL
+        WHERE eind_geldigheid IS NULL
     ) AS sub
     ON value->>'bronwaarde' = sub.identificatie
     GROUP BY catalog2_collection2._id
@@ -185,9 +185,9 @@ AND catalog2_collection2._id = enhanced._id
 UPDATE catalog2_collection2
 SET field_name = enhanced.related
 FROM (
-    SELECT catalog2_collection2._id, ('{"id": "'|| catalog3_collection3._id ||'"}')::JSONB as related
+    SELECT catalog2_collection2._id, ('{"identificatie": "'|| catalog3_collection3._id ||'"}')::JSONB as related
     FROM catalog2_collection2
-    LEFT JOIN catalog2_collection2 ON             catalog2_collection2.field2->>'id' = catalog2_collection2._id LEFT JOIN catalog3_collection3 ON             catalog2_collection2.field3->>'id' = catalog3_collection3._id
+    LEFT JOIN catalog2_collection2 ON             catalog2_collection2.field2->>'identificatie' = catalog2_collection2._id LEFT JOIN catalog3_collection3 ON             catalog2_collection2.field3->>'identificatie' = catalog3_collection3._id
 
 ) AS enhanced
 WHERE catalog2_collection2._application = 'source'


### PR DESCRIPTION
A migration was added to rename the columns to match the latest specifications. Changes were made to rename ‘id’ to ‘identificatie’ and ‘datum_einde_geldigheid’ to ‘eind_geldigheid’