### PR TITLE
Removed has_states from compare

### DIFF
--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -141,7 +141,7 @@ class GOBStorageHandler():
         table_name = self.gob_model.get_table_name(self.metadata.catalogue, self.metadata.entity)
         new_table_name = table_name + TEMPORARY_TABLE_SUFFIX
 
-        fields = ['_source_id', '_hash', collection['entity_id']]
+        fields = ['_source_id', '_hash']
 
         # Try if the temporary table is already present
         try:

--- a/src/gobupload/storage/queries.py
+++ b/src/gobupload/storage/queries.py
@@ -1,8 +1,4 @@
-def get_comparison_query(current, temporary, collection):
-    # If the collection has_states, take volgnummer into account
-    entity_id = collection['entity_id']
-    using = f"{entity_id}, volgnummer" if collection.get('has_states') else f"{entity_id}"
-
+def get_comparison_query(current, temporary):
     return f"""
 SELECT
     {temporary}._source_id,
@@ -14,7 +10,7 @@ FROM {temporary}
 FULL OUTER JOIN (
     SELECT * FROM {current}
     WHERE _date_deleted IS NULL
-    ) AS {current} USING ({using})
+    ) AS {current} USING (_source_id)
 WHERE (
     {temporary}._hash
 ) IS NOT DISTINCT FROM (
@@ -35,7 +31,7 @@ FROM {temporary}
 FULL OUTER JOIN (
     SELECT * FROM {current}
     WHERE _date_deleted IS NULL
-    ) AS {current} USING ({using})
+    ) AS {current} USING (_source_id)
 WHERE (
     {temporary}._hash
 ) IS DISTINCT FROM (

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -74,7 +74,7 @@ class TestStorageHandler(unittest.TestCase):
 
         collection = {'entity_id': 'identificatie'}
 
-        query = queries.get_comparison_query(current, temporary, collection)
+        query = queries.get_comparison_query(current, temporary)
 
         self.storage.compare_temporary_data()
 


### PR DESCRIPTION
Has states has been removed and compare is now done using _source_id. Creation of the temporary table has been simplified by using all_fields on the model