### PR TITLE
Fix relate issues

### DIFF
--- a/src/gobupload/relate/relate.py
+++ b/src/gobupload/relate/relate.py
@@ -74,6 +74,13 @@ def _handle_state_relation(state, relation, next_begin):
             "dst": [_no_dst(relation['dst'][0]['source'])]
         })
 
+    for result in results:
+        dst = result['dst']
+        not_none_items = [d for d in dst if d['id'] is not None]
+        if len(not_none_items) >= 1:
+            # Do not allow empty results when the list of dst's has valid dst items
+            result['dst'] = not_none_items
+
     return results
 
 
@@ -201,9 +208,9 @@ def _close_state(state, relations, previous, results):
     """
     if relations:
         dst_end = previous["dst_end"]
-        no_dst = _no_dst(previous["dst_source"])
         if dst_end != state["end"]:
             # Add an empty last relation
+            no_dst = _no_dst(previous["dst_source"])
             relations.append(_get_relation(dst_end, state["end"], no_dst))
         results.extend(_handle_state(state, relations))
 
@@ -267,8 +274,9 @@ def _handle_relations(rows):
                 "end": src_end,
             }
             relations = []
-            # Initialize start date
-            dst_begin = _add_relations_before_dst_begin(src_begin, dst_begin, dst_id, relations)
+
+        # Initialize start date
+        dst_begin = _add_relations_before_dst_begin(src_begin, dst_begin, dst_id, relations)
 
         # Take the minimum eind_geldigheid of src_id and dst
         if dst_end is None:
@@ -331,7 +339,8 @@ def _remove_gaps(results):
                 extra_data = {
                     'id': "inconsistency found",
                     'data': {
-                        'identificatie': src_id
+                        'identificatie': src_id,
+                        'volgnummer': src_volgnummer
                     }
                 }
                 logger.warning(f"Inconsistency found", extra_data)

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -148,7 +148,7 @@ def _get_fields(has_states):
     :return:
     """
     # Functional identification
-    BASE_FIELDS = [FIELD.SOURCE, FIELD.ID]
+    BASE_FIELDS = [FIELD.DATE_DELETED, FIELD.SOURCE, FIELD.ID]
     # State fields for collections with states
     STATE_FIELDS = [FIELD.SEQNR, FIELD.START_VALIDITY, FIELD.END_VALIDITY]
 
@@ -203,6 +203,7 @@ def get_current_relations(catalog_name, collection_name, field_name):
     query = f"""
 SELECT   {', '.join(select)}
 FROM     {table_name}
+WHERE    {FIELD.DATE_DELETED} IS NULL
 ORDER BY {', '.join(order_by)}
 """
     rows = _execute(query)
@@ -417,6 +418,8 @@ def get_relations(src_catalog_name, src_collection_name, src_field_name):
     select_from = _get_select_from(dst_fields, dst_match_fields, src_fields, src_match_fields)
     select_from_join = _get_select_from_join(dst_fields, dst_match_fields)
 
+    not_deleted = f"(src.{FIELD.DATE_DELETED} IS NULL AND dst.{FIELD.DATE_DELETED} IS NULL)"
+
     query = f"""
 SELECT
     {comma_join.join(select_from)}
@@ -428,7 +431,8 @@ FROM {dst_table_name}) AS dst
 ON
     {and_join.join(join_on)}
 WHERE
-    {or_join.join(has_bronwaarde)}
+    {or_join.join(has_bronwaarde)} AND
+    {not_deleted}
 ORDER BY
     {', '.join(order_by)}
 """

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -59,6 +59,7 @@ WHERE  _gobid = _gobid
         mock_execute.assert_called_with("""
 SELECT   _gobid, field, _source, _id
 FROM     catalog_collection
+WHERE    _date_deleted IS NULL
 ORDER BY _source, _id
 """)
 
@@ -81,6 +82,7 @@ ORDER BY _source, _id
         mock_execute.assert_called_with("""
 SELECT   _gobid, field, _source, _id, volgnummer, eind_geldigheid
 FROM     catalog_collection
+WHERE    _date_deleted IS NULL
 ORDER BY _source, _id, volgnummer, begin_geldigheid
 """)
 
@@ -105,14 +107,17 @@ ORDER BY _source, _id, volgnummer, begin_geldigheid
         ]
         expect = """
 SELECT
+    src._date_deleted AS src__date_deleted,
     src._source AS src__source,
     src._id AS src__id,
+    dst._date_deleted AS dst__date_deleted,
     dst._source AS dst__source,
     dst._id AS dst__id,
     dst.dst_attr AS dst_match_dst_attr
 FROM catalog_collection AS src
 LEFT OUTER JOIN (
 SELECT
+    _date_deleted,
     _source,
     _id,
     dst_attr
@@ -120,7 +125,8 @@ FROM dst_catalogue_dst_collection) AS dst
 ON
     (src._application = 'src_application' AND dst.dst_attr = src.src_attr->>'bronwaarde')
 WHERE
-    (src._application = 'src_application' AND src.src_attr->>'bronwaarde' IS NOT NULL)
+    (src._application = 'src_application' AND src.src_attr->>'bronwaarde' IS NOT NULL) AND
+    (src._date_deleted IS NULL AND dst._date_deleted IS NULL)
 ORDER BY
     src._source, src._id
 """
@@ -150,11 +156,13 @@ ORDER BY
         ]
         expect = """
 SELECT
+    src._date_deleted AS src__date_deleted,
     src._source AS src__source,
     src._id AS src__id,
     src.volgnummer AS src_volgnummer,
     src.begin_geldigheid AS src_begin_geldigheid,
     src.eind_geldigheid AS src_eind_geldigheid,
+    dst._date_deleted AS dst__date_deleted,
     dst._source AS dst__source,
     dst._id AS dst__id,
     dst.volgnummer AS dst_volgnummer,
@@ -164,6 +172,7 @@ SELECT
 FROM catalog_collection AS src
 LEFT OUTER JOIN (
 SELECT
+    _date_deleted,
     _source,
     _id,
     volgnummer,
@@ -176,7 +185,8 @@ ON
     (dst.begin_geldigheid < src.eind_geldigheid OR src.eind_geldigheid IS NULL) AND
     (dst.eind_geldigheid > src.begin_geldigheid OR dst.eind_geldigheid IS NULL)
 WHERE
-    (src._application = 'src_application' AND src.src_attr->>'bronwaarde' IS NOT NULL)
+    (src._application = 'src_application' AND src.src_attr->>'bronwaarde' IS NOT NULL) AND
+    (src._date_deleted IS NULL AND dst._date_deleted IS NULL)
 ORDER BY
     src._source, src._id, src.volgnummer, src.begin_geldigheid, dst.begin_geldigheid, dst.eind_geldigheid
 """
@@ -207,11 +217,13 @@ ORDER BY
         ]
         expect = """
 SELECT
+    src._date_deleted AS src__date_deleted,
     src._source AS src__source,
     src._id AS src__id,
     src.volgnummer AS src_volgnummer,
     src.begin_geldigheid AS src_begin_geldigheid,
     src.eind_geldigheid AS src_eind_geldigheid,
+    dst._date_deleted AS dst__date_deleted,
     dst._source AS dst__source,
     dst._id AS dst__id,
     dst.volgnummer AS dst_volgnummer,
@@ -221,6 +233,7 @@ SELECT
 FROM catalog_collection AS src
 LEFT OUTER JOIN (
 SELECT
+    _date_deleted,
     _source,
     _id,
     volgnummer,
@@ -233,7 +246,8 @@ ON
     (dst.begin_geldigheid < src.eind_geldigheid OR src.eind_geldigheid IS NULL) AND
     (dst.eind_geldigheid > src.begin_geldigheid OR dst.eind_geldigheid IS NULL)
 WHERE
-    (src._application = 'src_application' AND ARRAY(SELECT x->>'bronwaarde' FROM jsonb_array_elements(src.src_attr) as x) IS NOT NULL)
+    (src._application = 'src_application' AND ARRAY(SELECT x->>'bronwaarde' FROM jsonb_array_elements(src.src_attr) as x) IS NOT NULL) AND
+    (src._date_deleted IS NULL AND dst._date_deleted IS NULL)
 ORDER BY
     src._source, src._id, src.volgnummer, src.begin_geldigheid, dst.begin_geldigheid, dst.eind_geldigheid
 """
@@ -270,11 +284,13 @@ ORDER BY
         ]
         expect = """
 SELECT
+    src._date_deleted AS src__date_deleted,
     src._source AS src__source,
     src._id AS src__id,
     src.volgnummer AS src_volgnummer,
     src.begin_geldigheid AS src_begin_geldigheid,
     src.eind_geldigheid AS src_eind_geldigheid,
+    dst._date_deleted AS dst__date_deleted,
     dst._source AS dst__source,
     dst._id AS dst__id,
     dst.volgnummer AS dst_volgnummer,
@@ -285,6 +301,7 @@ SELECT
 FROM catalog_collection AS src
 LEFT OUTER JOIN (
 SELECT
+    _date_deleted,
     _source,
     _id,
     volgnummer,
@@ -300,7 +317,8 @@ ON
     (dst.eind_geldigheid > src.begin_geldigheid OR dst.eind_geldigheid IS NULL)
 WHERE
     (src._application = 'src_application1' AND src.src_attr1->>'bronwaarde' IS NOT NULL) OR
-    (src._application = 'src_application2' AND src.src_attr2->>'bronwaarde' IS NOT NULL)
+    (src._application = 'src_application2' AND src.src_attr2->>'bronwaarde' IS NOT NULL) AND
+    (src._date_deleted IS NULL AND dst._date_deleted IS NULL)
 ORDER BY
     src._source, src._id, src.volgnummer, src.begin_geldigheid, dst.begin_geldigheid, dst.eind_geldigheid
 """


### PR DESCRIPTION
Include only non-deleted items

Skip empty items in relations, eg
- 2008-2008 => x1, None
- 2008-2009 => None
- 2009-2011 => x2
Becomes
- 2008-2008 => x1
- 2008-2009 => None
- 2009-2011 => x2

Allow for gaps in many-reference relations