### PR TITLE
Streaming

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -49,4 +49,4 @@ SERVICEDEFINITION = {
 storage = GOBStorageHandler()
 storage.init_storage()
 
-messagedriven_service(SERVICEDEFINITION, "Upload")
+messagedriven_service(SERVICEDEFINITION, "Upload", {"stream_contents": True})

--- a/src/gobupload/compare/event_collector.py
+++ b/src/gobupload/compare/event_collector.py
@@ -16,7 +16,6 @@ class EventCollector:
         Initializes the collector with empty collections
 
         """
-        self.events = []
         self._bulk_events = []
         self._last_type = None
         self.contents_writer = contents_writer

--- a/src/gobupload/compare/event_collector.py
+++ b/src/gobupload/compare/event_collector.py
@@ -11,7 +11,7 @@ class EventCollector:
     MAX_BULK = 10000          # Max number of events of same type in one bulk event
     BULK_TYPES = ["CONFIRM"]  # Only CONFIRM events are grouped in bulk events
 
-    def __init__(self):
+    def __init__(self, contents_writer):
         """
         Initializes the collector with empty collections
 
@@ -19,6 +19,7 @@ class EventCollector:
         self.events = []
         self._bulk_events = []
         self._last_type = None
+        self.contents_writer = contents_writer
 
     def __enter__(self):
         return self
@@ -33,7 +34,7 @@ class EventCollector:
         :param event:
         :return:
         """
-        self.events.append(event)
+        self.contents_writer.write(event)
 
     def _add_bulk_event(self, event):
         """

--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -51,9 +51,8 @@ def compare(msg):
         enricher = Enricher(storage, msg)
         populator = Populator(entity_model, msg)
 
-        with EntityCollector(storage) as entity_collector, \
-                msg["contents"] as contents:
-            for entity in contents.items:
+        with EntityCollector(storage) as entity_collector:
+            for entity in msg["contents"]:
                 stats.collect(entity)
                 enricher.enrich(entity)
                 populator.populate(entity)

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -249,9 +249,13 @@ class GOBStorageHandler():
         class session_context:
             def __enter__(ctx):
                 self.session = Session(self.engine)
+                return self.session
 
-            def __exit__(ctx, type, value, traceback):
-                self.session.commit()
+            def __exit__(ctx, exc_type, exc_val, exc_tb):
+                if exc_type is not None:
+                    self.session.rollback()
+                else:
+                    self.session.commit()
                 self.session.close()
                 self.session = None
 

--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -12,8 +12,31 @@ from gobcore.events.import_message import MessageMetaData
 
 class EventApplicator:
 
+    MAX_ADD_CHUNK = 10000
+
     def __init__(self, storage):
         self.storage = storage
+        # Use a lookup table to tell if an entity is new to the collection
+        # New entities are added in bulk
+        self.source_ids = self.storage.get_current_ids(exclude_deleted=False)
+        self.add_events = []
+
+    def __enter__(self):
+        self.add_events = []
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.apply_add_events()
+
+    def add_add_event(self, event):
+        self.add_events.append(event)
+        if len(self.add_events) >= self.MAX_ADD_CHUNK:
+            self.apply_add_events()
+
+    def apply_add_events(self):
+        if self.add_events:
+            self.storage.add_add_events(self.add_events)
+            self.add_events = []
 
     def apply(self, event):
         # Parse the json data of the event
@@ -30,6 +53,8 @@ class EventApplicator:
             self.storage.bulk_update_confirms(gob_event, event.eventid)
             action = "CONFIRM"
             count = len(gob_event._data['confirms'])
+        elif isinstance(gob_event, GOB.ADD) and data["_entity_source_id"] not in self.source_ids:
+            self.add_add_event(gob_event)
         else:
             # Get the entity to which the event should be applied, create if ADD event
             entity = self.storage.get_entity_for_update(event, data)

--- a/src/gobupload/update/event_collector.py
+++ b/src/gobupload/update/event_collector.py
@@ -34,7 +34,8 @@ class EventCollector:
 
     def store_events(self):
         if len(self.events):
-            return self.storage.add_events(self.events)
+            self.storage.add_events(self.events)
+            self.events = []
 
     def collect(self, event):
         """

--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -65,8 +65,9 @@ def _store_events(storage, events, stats):
         event_collector = EventCollector(storage)
 
         with ProgressTicker("Store events", 10000) as progress, \
-                EventCollector(storage) as event_collector:
-            for event in events:
+                EventCollector(storage) as event_collector, \
+                events as contents:
+            for event in contents.items:
                 progress.tick()
 
                 if event_collector.collect(event):
@@ -124,7 +125,7 @@ def full_update(msg):
     storage = GOBStorageHandler(metadata)
 
     # Get events from message
-    events = message.contents["events"]
+    events = msg["contents"]
 
     # Gather statistics of update process
     stats = UpdateStatistics()
@@ -138,4 +139,9 @@ def full_update(msg):
     logger.info(f"Update completed", {'data': results})
 
     # Return the result message, with no log, no contents
-    return ImportMessage.create_import_message(msg["header"], None, None)
+    message = {
+        "header": msg["header"],
+        "summary": results,
+        "contents": None
+    }
+    return message

--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -65,9 +65,8 @@ def _store_events(storage, events, stats):
         event_collector = EventCollector(storage)
 
         with ProgressTicker("Store events", 10000) as progress, \
-                EventCollector(storage) as event_collector, \
-                events as contents:
-            for event in contents.items:
+                EventCollector(storage) as event_collector:
+            for event in events:
                 progress.tick()
 
                 if event_collector.collect(event):

--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -24,9 +24,8 @@ def _apply_events(storage, start_after, stats):
     with storage.get_session():
         logger.info(f"Apply events")
 
-        event_applicator = EventApplicator(storage)
-
-        with ProgressTicker("Apply events", 10000) as progress:
+        with ProgressTicker("Apply events", 10000) as progress, \
+                EventApplicator(storage) as event_applicator:
             unhandled_events = storage.get_events_starting_after(start_after)
             for event in unhandled_events:
                 progress.tick()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.67f#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.5.68a#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/tests/compare/test_compare.py
+++ b/src/tests/compare/test_compare.py
@@ -177,8 +177,10 @@ class TestCompare(TestCase):
         mock_writer.return_value.__enter__().write.assert_called_once()
         mock_writer.return_value.__enter__().write.assert_called_with({'event': 'MODIFY', 'data': ANY})
 
+        result = mock_writer.return_value.__enter__().write.call_args_list[0][0][0]
+
         # modificatinos dict has correct modifications.
-        modifications = result['contents']['events'][0]['data']['modifications']
+        modifications = result['data']['modifications']
         self.assertEqual(len(modifications), 1)
         self.assertEqual(modifications[0]['key'], field_name)
         self.assertEqual(modifications[0]['old_value'], old_value)

--- a/src/tests/compare/test_event_collector.py
+++ b/src/tests/compare/test_event_collector.py
@@ -1,36 +1,39 @@
 from unittest import TestCase
+from unittest.mock import MagicMock, patch
 
+from gobcore.message_broker.offline_contents import ContentsWriter
 from gobupload.compare.event_collector import EventCollector
 
+mock_writer = MagicMock(spec=ContentsWriter)
+
+@patch('gobupload.compare.main.ContentsWriter', mock_writer)
 class TestEventCollector(TestCase):
 
     def setUp(self):
-        pass
+        mock_writer.reset_mock()
 
     def tearDown(self):
         pass
 
     def test_add_empty(self):
-        result = None
-        with EventCollector() as ec:
-            result = ec.events
-        self.assertEqual(result, [])
+        with EventCollector(mock_writer) as ec:
+            pass
+        mock_writer.assert_not_called()
 
     def test_add_one(self):
-        result = None
-        with EventCollector() as ec:
+        with EventCollector(mock_writer) as ec:
             ec.add({"event": 1})
-            result = ec.events
-        self.assertEqual(result, [{"event": 1}])
+        mock_writer.write.assert_called_once()
+        mock_writer.write.assert_called_with({"event": 1})
 
     def test_add_multiple(self):
-        result = None
-        with EventCollector() as ec:
+        with EventCollector(mock_writer) as ec:
             ec.add({"event": 1})
+            mock_writer.write.assert_called_with({"event": 1})
             ec.add({"event": 2})
+            mock_writer.write.assert_called_with({"event": 2})
             ec.add({"event": 3})
-            result = ec.events
-        self.assertEqual(result, [{"event": 1}, {"event": 2}, {"event": 3}])
+            mock_writer.write.assert_called_with({"event": 3})
 
     def test_add_bulk_one(self):
         confirm_event = {
@@ -41,11 +44,10 @@ class TestEventCollector(TestCase):
             }
         }
 
-        result = None
-        with EventCollector() as ec:
+        with EventCollector(mock_writer) as ec:
             ec.add(confirm_event)
-            result = ec.events
-        self.assertEqual(result, [confirm_event])
+        mock_writer.write.assert_called_once()
+        mock_writer.write.assert_called_with(confirm_event)
 
     def test_add_bulk_multi(self):
         confirm_event = {
@@ -67,18 +69,18 @@ class TestEventCollector(TestCase):
             }
         }
 
-        result = None
-        with EventCollector() as ec:
+        with EventCollector(mock_writer) as ec:
             ec.add(confirm_event)
             ec.add(confirm_event)
-            result = ec.events
-        self.assertEqual(result, [expectation])
+        mock_writer.write.assert_called_once()
+        mock_writer.write.assert_called_with(expectation)
+
+        mock_writer.reset_mock()
 
         EventCollector.MAX_BULK = 2
-        result = None
-        with EventCollector() as ec:
+        with EventCollector(mock_writer) as ec:
             ec.add(confirm_event)
             ec.add(confirm_event)
+            mock_writer.write.assert_called_with(expectation)
             ec.add(confirm_event)
-            result = ec.events
-        self.assertEqual(result, [expectation, confirm_event])
+        mock_writer.write.assert_called_with(confirm_event)

--- a/src/tests/compare/test_main.py
+++ b/src/tests/compare/test_main.py
@@ -6,7 +6,7 @@ class TestMain(TestCase):
     @mock.patch('gobcore.message_broker.messagedriven_service.messagedriven_service')
     def test_main_calls_service_with_definition(self, mock_service, mock_storage):
         from gobupload import __main__
-        mock_service.assert_called_with(__main__.SERVICEDEFINITION, "Upload")
+        mock_service.assert_called_with(__main__.SERVICEDEFINITION, "Upload", {"stream_contents": True})
 
     # Mock this, to prevent service from starting when importing __main__
     @mock.patch('gobupload.storage.handler.GOBStorageHandler')

--- a/src/tests/fixtures.py
+++ b/src/tests/fixtures.py
@@ -101,10 +101,7 @@ def get_event_message_fixture(event_name=None):
     message = get_message_fixture()
     metadata = message['header']
     event = get_event_fixture(metadata, event_name)
-    message['contents'] = {
-        "events": [event],
-        "recompares": []
-    }
+    message['contents'] = [event]
 
     for field in event['data'].keys():
         if field != '_source_id':

--- a/src/tests/test_update.py
+++ b/src/tests/test_update.py
@@ -43,7 +43,7 @@ class TestUpdate(TestCase):
         message = fixtures.get_event_message_fixture()
         full_update(message)
 
-        self.mock_storage.add_events.assert_called_with(message['contents']['events'])
+        self.mock_storage.add_events.assert_called_with(message['contents'])
 
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main._get_event_ids')
@@ -96,7 +96,7 @@ class TestUpdate(TestCase):
             mock_event.return_value = gob_event
 
             message = fixtures.get_event_message_fixture(event_to_test.name)
-            id_to_pop = message['contents']['events'][0]['data']['_source_id']
+            id_to_pop = message['contents'][0]['data']['_source_id']
             gob_event.pop_ids.return_value = id_to_pop, id_to_pop
 
             self.mock_storage.get_events_starting_after.return_value = []

--- a/src/tests/update/test_event_applicator.py
+++ b/src/tests/update/test_event_applicator.py
@@ -1,0 +1,69 @@
+import json
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from tests.fixtures import dict_to_object
+
+from gobupload.storage.handler import GOBStorageHandler
+from gobupload.update.event_applicator import EventApplicator
+
+
+class TestEventCollector(TestCase):
+
+    def setUp(self):
+        self.storage = MagicMock(spec=GOBStorageHandler)
+        self.mock_event = {
+            'version': '0.1',
+            'catalogue': 'test_catalogue',
+            'application': 'TEST',
+            'entity': 'test_entity',
+            'timestamp': None,
+            'source': 'test',
+            'action': 'ADD',
+            'source_id': 'source_id',
+            'contents': None
+        }
+
+    def tearDown(self):
+        pass
+
+    def set_contents(self, contents):
+        self.mock_event["contents"] = json.dumps(contents)
+
+    def test_constructor(self):
+        applicator = EventApplicator(self.storage)
+        self.assertEqual(applicator.add_events, [])
+
+    def test_apply(self):
+        applicator = EventApplicator(self.storage)
+        self.mock_event["action"] = 'CONFIRM'
+        self.set_contents({
+            '_entity_source_id': 'entity_source_id',
+            '_hash': '123'
+        })
+        event = dict_to_object(self.mock_event)
+        applicator.apply(event)
+        self.assertEqual(len(applicator.add_events), 0)
+
+    def test_apply_new_add(self):
+        applicator = EventApplicator(self.storage)
+        self.set_contents({
+            '_entity_source_id': 'entity_source_id',
+            '_hash': '123'
+        })
+        event = dict_to_object(self.mock_event)
+        applicator.apply(event)
+        self.assertEqual(len(applicator.add_events), 1)
+
+    def test_apply_bulk(self):
+        applicator = EventApplicator(self.storage)
+        self.mock_event["action"] = 'BULKCONFIRM'
+        self.set_contents({
+            'confirms': [{
+                '_entity_source_id': 'entity_source_id'
+            }]
+        })
+        event = dict_to_object(self.mock_event)
+        applicator.apply(event)
+        self.assertEqual(len(applicator.add_events), 0)

--- a/src/tests/update/test_event_collector.py
+++ b/src/tests/update/test_event_collector.py
@@ -1,0 +1,91 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from gobupload.storage.handler import GOBStorageHandler
+from gobupload.update.event_collector import EventCollector
+
+
+class TestEventCollector(TestCase):
+
+    def setUp(self):
+        self.storage = MagicMock(spec=GOBStorageHandler)
+
+    def tearDown(self):
+        pass
+
+    def test_constructor(self):
+        collector = EventCollector(self.storage)
+        self.assertEqual(collector.events, [])
+
+    def test_add_regular_event(self):
+        collector = EventCollector(self.storage)
+        collector.add_event({'event': 'any event'})
+        self.assertEqual(collector.events, [{'event': 'any event'}])
+
+    def test_add_bulk_event(self):
+        collector = EventCollector(self.storage)
+        collector.add_event({'event': 'BULKCONFIRM'})
+        self.assertEqual(collector.events, [])
+        print(self.storage.mock_calls)
+        self.storage.add_events.assert_called_with([{'event': 'BULKCONFIRM'}])
+
+    def test_validate(self):
+        self.storage.get_last_events.return_value = {
+            1: 100
+        }
+        collector = EventCollector(self.storage)
+
+        event = {
+            'event': 'event',
+            'data': {
+                '_entity_source_id': 1,
+                '_last_event': 100
+            }
+        }
+        result = collector._validate(event)
+        self.assertEqual(result, True)
+
+        event['data']['_last_event'] = 50
+        result = collector._validate(event)
+        self.assertEqual(result, False)
+
+        event['data']['_entity_source_id'] = 2
+        result = collector._validate(event)
+        self.assertEqual(result, False)
+
+    def test_validate_bulk(self):
+        self.storage.get_last_events.return_value = {
+            1: 100
+        }
+        collector = EventCollector(self.storage)
+
+        event = {
+            'event': 'BULKCONFIRM',
+            'data': {
+                'confirms': [{
+                    '_source_id': 1,
+                    '_last_event': 100
+                }]
+            }
+        }
+        result = collector._validate(event)
+        self.assertEqual(result, True)
+
+        event['data']['confirms'][0]['_last_event'] = 50
+        result = collector._validate(event)
+        self.assertEqual(result, False)
+
+        event['data']['confirms'][0]['_entity_source_id'] = 2
+        result = collector._validate(event)
+        self.assertEqual(result, False)
+
+    def test_exit(self):
+        EventCollector.MAX_CHUNK = 2
+        collector = EventCollector(self.storage)
+        collector.add_event({'event': 'any event'})
+        self.assertEqual(collector.events, [{'event': 'any event'}])
+        collector.add_event({'event': 'any event'})
+        self.assertEqual(collector.events, [])
+        self.storage.add_events.assert_called_with([{'event': 'any event'}, {'event': 'any event'}])
+
+


### PR DESCRIPTION
Compare reads entities from json stream
writes entities into a temporary table

Events are generated by comparing the temporary table with actual table
streams resulting events in a file

Update reads events from json stream
and writes the events into the events table

The new events are read from the events table
and applied onto the current entities