### PR TITLE
Treat skipped events as warnings

### DIFF
--- a/src/gobupload/compare/enrich.py
+++ b/src/gobupload/compare/enrich.py
@@ -164,6 +164,4 @@ def _autoid(storage, data, specs, column, assigned):
     assigned[column]["issued"][data[on]] = value    # Register the issuance for the give 'on' value
     assigned[column]["last"] = value    # Register that last issued value
 
-    logging = f"{specs['type']}: {column} = '{value}' for {on} = '{data[on]}'"
-
-    return value, logging
+    return value, None

--- a/src/gobupload/update/update_statistics.py
+++ b/src/gobupload/update/update_statistics.py
@@ -71,4 +71,5 @@ class UpdateStatistics():
     def log(self):
         for process in ["stored", "skipped", "applied"]:
             for action, n in getattr(self, process).items():
-                logger.info(f"{n} {action} events {process}")
+                log = logger.warning if process == "skipped" else logger.info
+                log(f"{n} {action} events {process}")


### PR DESCRIPTION
Skipped events mean that events have been derived from
old entity states.