### PR TITLE
Change string quotation in RelationUpdater

### DIFF
--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -240,7 +240,7 @@ class RelationUpdater:
         """
         query = f"""
 UPDATE {self.table_name}
-SET    {field_name} = '{json.dumps(row[field_name])}'
+SET    {field_name} = $quotedString${json.dumps(row[field_name])}$quotedString$
 WHERE  {FIELD.GOBID} = {row[FIELD.GOBID]}
 """
         self.queries.append(query)

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -33,7 +33,7 @@ WHERE  catalogue = 'catalog' AND
         updater.update("field", {"field": "field", "_gobid": "_gobid"})
         self.assertEqual(updater.queries, ["""
 UPDATE catalog_collection
-SET    field = '"field"'
+SET    field = $quotedString$"field"$quotedString$
 WHERE  _gobid = _gobid
 """
         ])


### PR DESCRIPTION
New way of relating using JSON lists may include strings within the JSON with single quotes.