### PR TITLE
Relate event order by descending

### DIFF
--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -173,7 +173,7 @@ FROM   events
 WHERE  catalogue = '{catalog_name}' AND
        entity = '{collection_name}' AND
        action != 'CONFIRM'
-ORDER BY eventid
+ORDER BY eventid DESC
 LIMIT 1
 """
     last_change = _execute(query).scalar()

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -25,7 +25,7 @@ FROM   events
 WHERE  catalogue = 'catalog' AND
        entity = 'collection' AND
        action != 'CONFIRM'
-ORDER BY eventid
+ORDER BY eventid DESC
 LIMIT 1
 """)
 


### PR DESCRIPTION
The order by was sorting ascending instead of ascending, resulting in unchanged relations after new events were added