### PR TITLE
Re-add primary key and timestamp in query

### DIFF
--- a/src/alembic/versions/21aa7c3e62b0_add_primary_key.py
+++ b/src/alembic/versions/21aa7c3e62b0_add_primary_key.py
@@ -1,0 +1,25 @@
+"""Add primary key
+
+Revision ID: 21aa7c3e62b0
+Revises: 8ed83f51654b
+Create Date: 2019-05-23 14:23:24.500330
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+
+
+# revision identifiers, used by Alembic.
+revision = '21aa7c3e62b0'
+down_revision = '8ed83f51654b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('ALTER TABLE events ADD CONSTRAINT events_pkey PRIMARY KEY (eventid)')
+
+
+def downgrade():
+    op.execute('ALTER TABLE events DROP CONSTRAINT IF EXISTS events_pkey')

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -172,7 +172,7 @@ FROM   events
 WHERE  catalogue = '{catalog_name}' AND
        entity = '{collection_name}' AND
        action != 'CONFIRM'
-ORDER BY eventid DESC
+ORDER BY eventid, timestamp DESC
 LIMIT 1
 """
     last_change = _execute(query).scalar()

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -25,7 +25,7 @@ FROM   events
 WHERE  catalogue = 'catalog' AND
        entity = 'collection' AND
        action != 'CONFIRM'
-ORDER BY eventid DESC
+ORDER BY eventid, timestamp DESC
 LIMIT 1
 """)
 


### PR DESCRIPTION
Removing the primary key caused issues with automap in sqlalchemy. Therefor we’ve added a second order by key to bypass postgress choosing the wrong index