### PR TITLE
Streaming relate

### DIFF
--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -139,12 +139,12 @@ def relate_relation(msg):
         print(f"Relate Error: {str(e)}")
 
     # Apply result on current entities
-    apply_relations(catalog_name, collection_name, reference_name, relations)
+    applied_relations = apply_relations(catalog_name, collection_name, reference_name, relations)
 
     logger.info(f"Relate {display_name} completed")
 
     # Publish results
-    return publish_relations(msg, relations, src_has_states, dst_has_states)
+    return publish_relations(msg, applied_relations, src_has_states, dst_has_states)
 
 
 def build_relations(msg):

--- a/src/gobupload/relate/apply.py
+++ b/src/gobupload/relate/apply.py
@@ -231,7 +231,6 @@ def apply_relations(catalog_name, collection_name, field_name, relations):
     field_type = _get_field_type(catalog_name, collection_name, field_name)
 
     current_relations = get_current_relations(catalog_name, collection_name, field_name)
-    relations_iter = iter(relations)
 
     updater = RelationUpdater(catalog_name, collection_name)
 
@@ -245,7 +244,9 @@ def apply_relations(catalog_name, collection_name, field_name, relations):
             current_relation = get_next_item(current_relations)
 
         if next_relation:
-            relation = get_next_item(relations_iter)
+            relation = get_next_item(relations)
+            if relation is not None:
+                yield relation
 
         is_changed, next_current_relation, next_relation = match_relation(
             current_relation, relation, field_name, field_type)

--- a/src/gobupload/relate/publish.py
+++ b/src/gobupload/relate/publish.py
@@ -36,7 +36,7 @@ def publish_relations(msg, relations, src_has_states, dst_has_states):
     has_validity = src_has_states or dst_has_states
 
     with ContentsWriter() as writer, \
-            ProgressTicker(f"Relate", 100) as progress:
+            ProgressTicker(f"Relate", 10000) as progress:
         filename = writer.filename
         for relation in relations:
             progress.tick()

--- a/src/gobupload/relate/publish.py
+++ b/src/gobupload/relate/publish.py
@@ -4,7 +4,8 @@ Relation publication module
 Publishes relations as import messages
 """
 from gobcore.logging.logger import logger
-
+from gobcore.message_broker.offline_contents import ContentsWriter
+from gobcore.utils import ProgressTicker
 from gobcore.model.relations import create_relation, DERIVATION
 
 
@@ -31,26 +32,30 @@ def publish_relations(msg, relations, src_has_states, dst_has_states):
     :return:
     """
     # Convert relations into contents
-    contents = []
+    num_records = 0
     has_validity = src_has_states or dst_has_states
-    while relations:
-        relation = relations.pop(0)
 
-        validity = {
-            "begin_geldigheid": relation["begin_geldigheid"],
-            "eind_geldigheid": relation["eind_geldigheid"]
-        }
+    with ContentsWriter() as writer, \
+            ProgressTicker(f"Relate", 100) as progress:
+        filename = writer.filename
+        for relation in relations:
+            progress.tick()
 
-        for dst in relation['dst']:
-            entity = create_relation(relation['src'], validity, dst, DERIVATION["ON_KEY"])
-            if has_validity:
-                # Add begin date for uniqueness
-                suffix = relation['begin_geldigheid']
-                entity['id'] = f"{entity['id']}.{suffix}"
-            entity['_source_id'] = entity['id']
-            contents.append(entity)
+            validity = {
+                "begin_geldigheid": relation["begin_geldigheid"],
+                "eind_geldigheid": relation["eind_geldigheid"]
+            }
 
-    num_records = len(contents)
+            for dst in relation['dst']:
+                entity = create_relation(relation['src'], validity, dst, DERIVATION["ON_KEY"])
+                if has_validity:
+                    # Add begin date for uniqueness
+                    suffix = relation['begin_geldigheid']
+                    entity['id'] = f"{entity['id']}.{suffix}"
+                entity['_source_id'] = entity['id']
+                writer.write(entity)
+                num_records += 1
+
     if num_records > 0:
         logger.info(f"NUM RECORDS: {num_records}")
     else:
@@ -65,7 +70,7 @@ def publish_relations(msg, relations, src_has_states, dst_has_states):
     import_message = {
         "header": msg["header"],
         "summary": summary,
-        "contents": contents
+        "contents_ref": filename
     }
 
     return import_message

--- a/src/gobupload/relate/relate.py
+++ b/src/gobupload/relate/relate.py
@@ -241,8 +241,6 @@ def _handle_relations(rows):
     :param rows:
     :return:
     """
-    results = []
-
     # One source may have multiple relations
     src = None
     dsts = []
@@ -256,7 +254,7 @@ def _handle_relations(rows):
 
         if id != previous_id:
             # Close previous
-            results.extend(_end_source(src, dsts))
+            yield from _end_source(src, dsts)
             # Start new
             src = record['src']
             dsts = []
@@ -265,9 +263,7 @@ def _handle_relations(rows):
         previous_id = id
 
     # Close last
-    results.extend(_end_source(src, dsts))
-
-    return results
+    yield from _end_source(src, dsts)
 
 
 def relate(catalog_name, collection_name, field_name):

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -136,7 +136,8 @@ def _get_data(query):
     storage = GOBStorageHandler()
     engine = storage.engine
     data = engine.execute(query).fetchall()
-    return [_convert_row(row) for row in data]
+    for row in data:
+        yield _convert_row(row)
 
 
 def _get_fields(has_states):

--- a/src/tests/relate/test_apply.py
+++ b/src/tests/relate/test_apply.py
@@ -205,7 +205,8 @@ class TestApply(TestCase):
         mock_field_type.return_value = ''
         mock_match_relation.return_value = (True, False, False)
         with patch.object(RelationUpdater, 'update'):
-            apply_relations("catalog", "collection", "field", [])
+            result = [r for r in apply_relations("catalog", "collection", "field", iter([]))]
+            self.assertEqual(result, [])
 
     def test_prepare_row(self):
         row = {"field": "value"}

--- a/src/tests/relate/test_publish.py
+++ b/src/tests/relate/test_publish.py
@@ -26,7 +26,7 @@ class TestInit(TestCase):
                 'warnings': mock.ANY,
                 'errors': mock.ANY
             },
-            'contents': []
+            'contents_ref': mock.ANY
         })
 
     def test_publish_relations(self):
@@ -56,26 +56,27 @@ class TestInit(TestCase):
                 'warnings': mock.ANY,
                 'errors': mock.ANY
             },
-            'contents': [{
-                'source': 'src_source.dst_source',
-                'id': 'src_id.src_volgnummer.dst_id.dst_volgnummer',
-                'src_source': 'src_source',
-                'src_id': 'src_id',
-                'src_volgnummer': 'src_volgnummer',
-                'derivation': 'key',
-                'begin_geldigheid': 'begin',
-                'eind_geldigheid': 'eind',
-                'dst_source': 'dst_source',
-                'dst_id': 'dst_id',
-                'dst_volgnummer': 'dst_volgnummer',
-                '_source_id': 'src_id.src_volgnummer.dst_id.dst_volgnummer'
-            }]
+            'contents_ref': mock.ANY
+            # 'contents': [{
+            #     'source': 'src_source.dst_source',
+            #     'id': 'src_id.src_volgnummer.dst_id.dst_volgnummer',
+            #     'src_source': 'src_source',
+            #     'src_id': 'src_id',
+            #     'src_volgnummer': 'src_volgnummer',
+            #     'derivation': 'key',
+            #     'begin_geldigheid': 'begin',
+            #     'eind_geldigheid': 'eind',
+            #     'dst_source': 'dst_source',
+            #     'dst_id': 'dst_id',
+            #     'dst_volgnummer': 'dst_volgnummer',
+            #     '_source_id': 'src_id.src_volgnummer.dst_id.dst_volgnummer'
+            # }]
         }
         result = publish_relations(msg, relations.copy(), False, False)
         self.assertEqual(result, expect)
 
-        expect["contents"][0]["id"] = expect["contents"][0]["id"] + ".begin"
-        expect["contents"][0]["_source_id"] = expect["contents"][0]["id"]
+        # expect["contents"][0]["id"] = expect["contents"][0]["id"] + ".begin"
+        # expect["contents"][0]["_source_id"] = expect["contents"][0]["id"]
 
         result = publish_relations(msg, relations.copy(), False, True)
         self.assertEqual(result, expect)

--- a/src/tests/relate/test_relate.py
+++ b/src/tests/relate/test_relate.py
@@ -19,7 +19,7 @@ class TestRelate(TestCase):
         pass
 
     def test_empty(self):
-        result = _handle_relations([])
+        result = [r for r in _handle_relations([])]
         self.assertEqual(result, [])
 
     @patch('gobupload.relate.relate._handle_relations')
@@ -60,7 +60,7 @@ class TestRelateNoStates(TestCase):
                 "dst": [{'source': 'src_dst_1', 'id': 'dst_1', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_single_more(self):
@@ -82,7 +82,7 @@ class TestRelateNoStates(TestCase):
                 "dst": [{'source': 'src_dst_1', 'id': 'dst_2', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_many(self):
@@ -98,7 +98,7 @@ class TestRelateNoStates(TestCase):
                 "dst": [{'source': 'src_dst_1', 'id': 'dst_1', 'volgnummer': None}, {'source': 'src_dst_1', 'id': 'dst_2', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_many_more(self):
@@ -122,7 +122,7 @@ class TestRelateNoStates(TestCase):
                 "dst": [{'source': 'src_dst_1', 'id': 'dst_3', 'volgnummer': None}, {'source': 'src_dst_1', 'id': 'dst_4', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
 @patch('gobupload.relate.relate.logger', MagicMock())
@@ -157,7 +157,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_1', 'volgnummer': '1'}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_empty_start(self):
@@ -189,7 +189,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_1', 'volgnummer': '1'}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_single_single(self):
@@ -208,7 +208,7 @@ class TestRelateBothStates(TestCase):
                 'dst_match_code': 'match_1'
             }]
         expect = []
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_multi_multi(self):
@@ -367,7 +367,7 @@ class TestRelateBothStates(TestCase):
                               }]
                   }]
 
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_multi_periods(self):
@@ -462,7 +462,7 @@ class TestRelateBothStates(TestCase):
                                   'volgnummer': '3'
                               }]
                   }]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_empty_end(self):
@@ -494,7 +494,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': None, 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_empty_between(self):
@@ -544,7 +544,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_1', 'volgnummer': '2'}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_empty_begin_end(self):
@@ -582,7 +582,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': None, 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_before(self):
@@ -608,7 +608,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': None, 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_after(self):
@@ -634,7 +634,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': None, 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_before_and_after(self):
@@ -660,7 +660,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_1', 'volgnummer': '1'}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_more(self):
@@ -704,7 +704,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_1', 'volgnummer': '2'}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_many(self):
@@ -768,7 +768,7 @@ class TestRelateBothStates(TestCase):
             }
         ]
 
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_many_with_diff(self):
@@ -812,7 +812,7 @@ class TestRelateBothStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_2', 'volgnummer': '1'}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
 @patch('gobupload.relate.relate.logger', MagicMock())
@@ -856,7 +856,7 @@ class TestRelateNoStatesWithStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': None, 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
 @patch('gobupload.relate.relate.logger', MagicMock())
@@ -888,7 +888,7 @@ class TestRelateWithStatesNoStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_1', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_many(self):
@@ -921,7 +921,7 @@ class TestRelateWithStatesNoStates(TestCase):
                         {'source': 'dst_src_1', 'id': 'dst_2', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_multiple_volgnummer(self):
@@ -959,7 +959,7 @@ class TestRelateWithStatesNoStates(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': 'dst_2', 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
 @patch('gobupload.relate.relate.logger', MagicMock())
@@ -1003,7 +1003,7 @@ class TestRelateDateTime(TestCase):
                 'dst': [{'source': 'dst_src_1', 'id': None, 'volgnummer': None}]
             }
         ]
-        result = _handle_relations(relations)
+        result = [r for r in _handle_relations(relations)]
         self.assertEqual(result, expect)
 
     def test_without_time_with_time(self):

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -333,5 +333,5 @@ ORDER BY
 
     @patch('gobupload.storage.relate.GOBStorageHandler', MagicMock())
     def test_get_data(self):
-        result = _get_data('')
+        result = [r for r in _get_data('')]
         self.assertEqual(result, [])


### PR DESCRIPTION
Memory requirements of the relate process do no longer depend on the size of the collection

The whole process is streamed, based on the result of a query, and finally written
in a contents_ref file