### PR TITLE
Use active garbage collection

### DIFF
--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -9,6 +9,8 @@ import json
 from gobcore.events import GOB, GobEvent
 from gobcore.events.import_message import MessageMetaData
 
+from gobupload.utils import ActiveGarbageCollection
+
 
 class EventApplicator:
 
@@ -34,8 +36,9 @@ class EventApplicator:
 
     def apply_add_events(self):
         if self.add_events:
-            self.storage.add_add_events(self.add_events)
-            self.add_events = []
+            with ActiveGarbageCollection("Apply add events"):
+                self.storage.add_add_events(self.add_events)
+                self.add_events = []
 
     def apply(self, event):
         # Parse the json data of the event

--- a/src/gobupload/utils.py
+++ b/src/gobupload/utils.py
@@ -1,0 +1,20 @@
+import gc
+
+
+class ActiveGarbageCollection:
+
+    def __init__(self, title):
+        assert gc.isenabled(), "Garbage collection should be enabled"
+        self.title = title
+
+    def __enter__(self):
+        self._collect("start")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._collect("completion")
+
+    def _collect(self, step):
+        n = gc.collect()
+        if n > 0:
+            print(f"{self.title}: freed {n} unreachable objects on {step}")

--- a/src/test.sh
+++ b/src/test.sh
@@ -10,4 +10,4 @@ echo "Running unit tests"
 pytest tests/
 
 echo "Running coverage tests"
-pytest --cov=gobupload --cov-report html --cov-fail-under=85
+pytest --cov=gobupload --cov-report html --cov-fail-under=86

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from gobupload.utils import ActiveGarbageCollection
+
+
+class TestUpdate(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    @patch('gobupload.utils.gc')
+    def testGarbageCollection(self, mocked_gc):
+        mocked_gc.collect = MagicMock(return_value=1)
+        with ActiveGarbageCollection("any title") as agc:
+            self.assertEqual(agc.title, "any title")
+            self.assertEqual(mocked_gc.collect.call_count, 1)
+        self.assertEqual(mocked_gc.collect.call_count, 2)


### PR DESCRIPTION
Trigger garbage collection actively
To prevent any unnecessary memory consumption