### PR TITLE
Relate key

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -58,6 +58,17 @@ SERVICEDEFINITION = {
             'key': 'relate_relation.result'
         }
     },
+    'check_relation': {
+        'exchange': WORKFLOW_EXCHANGE,
+        'queue': REQUEST_QUEUE,
+        'key': 'check_relation.start',
+        'handler': relate.check_relation,
+        'report': {
+            'exchange': WORKFLOW_EXCHANGE,
+            'queue': RESULT_QUEUE,
+            'key': 'check_relation.result'
+        }
+    },
 }
 
 # Initialize database tables

--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -83,6 +83,12 @@ def _process_references(msg, catalog_name, collection_name, references):
 
 
 def check_relation(msg):
+    """
+    Check for any dangling relations
+
+    :param msg:
+    :return:
+    """
     catalog_name = msg['header']['src_catalogue']
     collection_name = msg['header']['src_entity']
     reference_name = msg['header']['src_reference_name']

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -404,6 +404,10 @@ def check_relations(src_catalog_name, src_collection_name, src_field_name):
     where = " AND\n            ".join(where)
 
     # select all relations that do not have an entry in the relations table
+    #
+    # ->> 'bronwaarde' IS NOT NULL
+    # is True for all json fields that have a non NULL value for bronwaarde
+    #
     srcs_without_relations = f"""
 SELECT
     {select}
@@ -440,6 +444,10 @@ WHERE
     _query_missing(relations_without_dst, "dangling relations")
 
     # Select all relations without bronwaarde
+    #
+    # ->> 'bronwaarde' IS NULL
+    # is True for all json fields (including empty ones) that have no bronwaarde, or a null value for bronwaarde
+    #
     select = ["_id"]
     if src_has_states:
         select.extend(["volgnummer", "begin_geldigheid", "eind_geldigheid"])

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -348,6 +348,13 @@ def _get_select_from(dst_fields, dst_match_fields, src_fields, src_match_fields)
 
 
 def _query_missing(query, items_name):
+    """
+    Query for anu missing attributes
+
+    :param query: query to execute
+    :param items_name: name of the missing attribute
+    :return: None
+    """
     for data in _get_data(query):
         current = data.get('eind_geldigheid') is None
         msg = f"Missing {'' if current else 'historic'} {items_name}"
@@ -358,6 +365,17 @@ def _query_missing(query, items_name):
 
 
 def check_relations(src_catalog_name, src_collection_name, src_field_name):
+    """
+    Check relations for any dangling relations
+
+    Dangling can be because a relation exist without any bronwaarde
+    or the bronmwaarde cannot be matched with any referenced entity
+
+    :param src_catalog_name:
+    :param src_collection_name:
+    :param src_field_name:
+    :return: None
+    """
     # Get the source catalog, collection and field for the given names
     model = GOBModel()
 

--- a/src/tests/relate/test_init.py
+++ b/src/tests/relate/test_init.py
@@ -1,7 +1,7 @@
 from unittest import TestCase, mock
 from unittest.mock import MagicMock, patch
 
-from gobupload.relate import build_relations, _relation_needs_update, _process_references
+from gobupload.relate import build_relations, check_relation, _relation_needs_update, _process_references
 
 @patch('gobupload.relate.logger', MagicMock())
 class TestInit(TestCase):
@@ -34,3 +34,20 @@ class TestInit(TestCase):
         mock_needs_update.return_value = True
         result = _process_references({}, "catalog", "collection", {})
         self.assertEqual(result, [])
+
+    @patch('gobupload.relate.logger', MagicMock())
+    @patch('gobupload.relate.check_relations', MagicMock())
+    def test_check_relation(self):
+        msg = {
+            'header': {
+                'src_catalogue': 'any_src_catalogue',
+                'src_entity': 'any_src_entity',
+                'src_reference_name': 'any_src_reference_name'
+            }
+        }
+        result = check_relation(msg)
+        self.assertEqual(result, {
+            'header': msg['header'],
+            'summary': mock.ANY,
+            'contents': None
+        })

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -374,4 +374,4 @@ ORDER BY
              patch.object(GOBModel, 'has_states', lambda s, a, b: True):
             check_relations("any_catalog", "any_collection", "any_field name")
         mock_missing.assert_called()
-        self.assertEqual(mock_missing.call_count, 2)
+        self.assertEqual(mock_missing.call_count, 3)


### PR DESCRIPTION
If relations do not need any updates (because there was no change in any of the tables) all actions are skipped. This however also blocks any quality checks.

This PR proposes to always run all quality checks, even if the relations have not changed.
Any quality problems for static collections as gebieden will not get lost, but keep being reported