### PR TITLE
Fix issue in compare

### DIFF
--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -168,7 +168,7 @@ def _process_compare_results(storage, model, results, stats):
                 event = GOB.CONFIRM.create_event(source_id, source_id, data)
             elif row['type'] == 'MODIFY':
                 current_entity = storage.get_current_entity(entity)
-                modifications = get_modifications(current_entity, entity, model['fields'])
+                modifications = get_modifications(current_entity, entity, model['all_fields'])
                 event = get_event_for(current_entity, entity, modifications)
             elif row['type'] == 'DELETE':
                 source_id = row['_entity_source_id']

--- a/src/tests/compare/test_compare.py
+++ b/src/tests/compare/test_compare.py
@@ -180,7 +180,7 @@ class TestCompare(TestCase):
         mock_model.get_collection.return_value = {
             "entity_id": "identificatie",
             "version": 1,
-            "fields": {
+            "all_fields": {
                 field_name: {
                     "type": "GOB.String"
                 }


### PR DESCRIPTION
When comparing an entity with a changed _expiration_date the new date wasn’t seen as a change to the entity and thus resulting in a confirm event instead of a modify event. Comparisons now take all_fields in to account