### PR TITLE
Run migrate as a separate command

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -77,6 +77,8 @@ storage = GOBStorageHandler()
 
 # Migrate on request only
 if args.migrate:
+    print("Start migration")
     storage.init_storage()
-
-MessagedrivenService(SERVICEDEFINITION, "Upload", {"stream_contents": True, "thread_per_service": True}).start()
+    print("End migratiion")
+else:
+    MessagedrivenService(SERVICEDEFINITION, "Upload", {"stream_contents": True, "thread_per_service": True}).start()

--- a/src/tests/compare/test_main.py
+++ b/src/tests/compare/test_main.py
@@ -1,30 +1,36 @@
 import sys
+import importlib
 
 from unittest import TestCase, mock
 
 
 class TestMain(TestCase):
+
     @mock.patch('gobupload.storage.handler.GOBStorageHandler')
     @mock.patch('gobcore.message_broker.messagedriven_service.MessagedrivenService')
     def test_main_calls_service_with_definition(self, mock_service, mock_storage):
-        # With command line arguments
-        sys.argv = ['python -m gobupload', '--migrate']
-        from gobupload import __main__
-        mock_service.assert_called_with(__main__.SERVICEDEFINITION, "Upload", {"stream_contents": True,
-                                                                               "thread_per_service": True})
-        mock_service.return_value.start.assert_called_with()
-        mock_storage.return_value.init_storage.assert_called()
-
-    # Mock this, to prevent service from starting when importing __main__
-    @mock.patch('gobupload.storage.handler.GOBStorageHandler')
-    @mock.patch('gobcore.message_broker.messagedriven_service.messagedriven_service')
-    def test_servicedefenition(self, mock_service, mock_storage):
         # No command line arguments
         sys.argv = ['python -m gobupload']
         from gobupload import __main__
+        importlib.reload(__main__)
 
+        mock_service.assert_called_with(__main__.SERVICEDEFINITION, "Upload", {"stream_contents": True,
+                                                                               "thread_per_service": True})
+        mock_service.return_value.start.assert_called_with()
         mock_storage.return_value.init_storage.assert_not_called()
+
         for key, definition in __main__.SERVICEDEFINITION.items():
             self.assertTrue('queue' in definition)
             self.assertTrue('handler' in definition)
             self.assertTrue(callable(definition['handler']))
+
+    @mock.patch('gobupload.storage.handler.GOBStorageHandler')
+    @mock.patch('gobcore.message_broker.messagedriven_service.MessagedrivenService')
+    def test_main_calls_migrate(self, mock_service, mock_storage):
+        # With migrate command line arguments
+        sys.argv = ['python -m gobupload', '--migrate']
+        from gobupload import __main__
+        importlib.reload(__main__)
+
+        mock_service.return_value.start.assert_not_called()
+        mock_storage.return_value.init_storage.assert_called()


### PR DESCRIPTION
Execute any migrations and then quit