### PR TITLE
Reduce memory usage

### DIFF
--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -31,8 +31,15 @@ class TestStorageHandler(unittest.TestCase):
         message = ImportMessage(self.msg)
         metadata = message.metadata
 
+        GOBStorageHandler.base = MagicMock()
         self.storage = GOBStorageHandler(metadata)
         GOBStorageHandler.engine = MagicMock()
+
+    @patch("gobupload.storage.handler.automap_base", MagicMock())
+    def test_base(self):
+        GOBStorageHandler.base = None
+        GOBStorageHandler._set_base(update=True)
+        self.assertIsNotNone(GOBStorageHandler.base)
 
     @patch("gobupload.storage.handler.alembic")
     def test_init_storage(self, mock_alembic):
@@ -88,9 +95,6 @@ class TestStorageHandler(unittest.TestCase):
         expected_table = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}_tmp'
 
         self.storage.create_temporary_table()
-
-        # Assert the test table has been made
-        self.assertIn(expected_table, self.storage.base.metadata.tables)
 
         for entity in self.msg["contents"]:
             self.storage.write_temporary_entity(entity)

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -32,23 +32,24 @@ class TestStorageHandler(unittest.TestCase):
         metadata = message.metadata
 
         self.storage = GOBStorageHandler(metadata)
+        GOBStorageHandler.engine = MagicMock()
 
     @patch("gobupload.storage.handler.alembic")
     def test_init_storage(self, mock_alembic):
         self.storage._init_views = MagicMock()
         self.storage._get_reflected_base = MagicMock()
         self.storage._init_indexes = MagicMock()
+        self.storage._set_base = MagicMock()
 
         self.storage.init_storage()
         mock_alembic.config.main.assert_called_once()
 
         self.storage._init_views.assert_called_once()
-        self.storage._get_reflected_base.assert_called_once()
+        self.storage._set_base.assert_called_with(update=True)
         self.storage._init_indexes.assert_called_once()
 
 
     def test_init_indexes(self):
-        self.storage.engine = MagicMock()
         gobupload.storage.handler.indexes = {
             "indexname": {
                 "table_name": "sometable",
@@ -73,9 +74,13 @@ class TestStorageHandler(unittest.TestCase):
         self.storage._init_indexes()
         self.storage.engine.execute.assert_has_calls([
             call("CREATE INDEX IF NOT EXISTS \"indexname\" ON sometable USING BTREE(cola,colb)"),
+            call().close(),
             call("CREATE INDEX IF NOT EXISTS \"index2name\" ON someothertable USING BTREE(cola)"),
+            call().close(),
             call("CREATE INDEX IF NOT EXISTS \"geo_index\" ON table_with_geo USING GIST(geocol)"),
+            call().close(),
             call("CREATE INDEX IF NOT EXISTS \"json_index\" ON table_with_json USING GIN(somejsoncol)"),
+            call().close(),
         ])
 
 
@@ -102,8 +107,8 @@ class TestStorageHandler(unittest.TestCase):
         self.storage.base.metadata.tables = {expected_table: mock_table}
         self.storage.create_temporary_table()
 
-        # Assert the truncate function is called
-        self.storage.engine.execute.assert_any_call(f"TRUNCATE {expected_table}")
+        # Assert the drop function is called
+        self.storage.engine.execute.assert_any_call(f"DROP TABLE IF EXISTS {expected_table}")
 
         for entity in self.msg["contents"]:
             self.storage.write_temporary_entity(entity)

--- a/src/tests/storage/test_storage.py
+++ b/src/tests/storage/test_storage.py
@@ -45,8 +45,9 @@ class TestContextManager(unittest.TestCase):
         # restore in setUp patched code
         importlib.reload(handler)
 
-    @mock.patch("gobupload.storage.handler.Session")
-    def test_session_context(self, mock_session):
+    def test_session_context(self):
+        mock_session = mock.MagicMock()
+        handler.GOBStorageHandler.Session = mock_session
         storage = handler.GOBStorageHandler(fixtures.random_string())
 
         # assert starting situation
@@ -58,7 +59,7 @@ class TestContextManager(unittest.TestCase):
 
         # test session creation in context
         with storage.get_session():
-            mock_session.assert_called_with(storage.engine)
+            mock_session.assert_called_with()
             self.assertEqual(storage.session, mock_session_instance)
 
         # test session creation after leaving context:


### PR DESCRIPTION
Keep global data at class level
Use sessionmaker instead of Session
Initialize reflected base only once
close engine connection after statement has been executed