### PR TITLE
Fix event applicator for modify events

### DIFF
--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -367,7 +367,8 @@ class GOBStorageHandler():
         """
         return self.session.query(self.DbEvent).yield_per(10000) \
             .filter_by(source=self.metadata.source, catalogue=self.metadata.catalogue, entity=self.metadata.entity) \
-            .filter(self.DbEvent.eventid > eventid if eventid else True)
+            .filter(self.DbEvent.eventid > eventid if eventid else True) \
+            .order_by(self.DbEvent.eventid)
 
     @with_session
     def has_any_event(self, filter):

--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -62,6 +62,9 @@ class EventApplicator:
             # Initial add
             self.add_add_event(gob_event)
         else:
+            # If ADD events are waiting to be applied to the database, flush those first to make sure they exist
+            self.apply_add_events()
+
             # Get the entity to which the event should be applied, create if ADD event
             entity = self.storage.get_entity_for_update(event, data)
 
@@ -89,7 +92,7 @@ def _get_gob_event(event, data):
 
     if model_version != event.version:
         # Event should be migrated to the correct GOBModel version
-        data = GOBMigrations().migrate_event_data(data, event.catalogue, event.entity, model_version)
+        data = GOBMigrations().migrate_event_data(event, data, event.catalogue, event.entity, model_version)
 
     event_msg = {
         "event": event.action,

--- a/src/tests/update/test_event_applicator.py
+++ b/src/tests/update/test_event_applicator.py
@@ -134,6 +134,6 @@ class TestEventApplicator(TestCase):
 
         _get_gob_event(event, data)
 
-        mock_migrations().migrate_event_data.assert_called_with(data, event.catalogue, event.entity, target_version)
+        mock_migrations().migrate_event_data.assert_called_with(event, data, event.catalogue, event.entity, target_version)
 
         mock_gob_event.assert_called_with(expected_event_msg, expected_meta_data)


### PR DESCRIPTION
Events were not ordered by eventid when applying them to the database. The fix makes sure events are handled in order and event migration works for modify events