### PR TITLE
Update materialized views on relation tables with GOBID

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -71,6 +71,10 @@ parser.add_argument('--migrate',
                     action='store_true',
                     default=False,
                     help='migrate the database tables, views and indexes')
+parser.add_argument('--materialized_views',
+                    action='store_true',
+                    default=False,
+                    help='force recreation of materialized views')
 args = parser.parse_args()
 
 # Initialize database tables
@@ -79,7 +83,7 @@ storage = GOBStorageHandler()
 # Migrate on request only
 if args.migrate:
     print("Storage migration forced")
-    storage.init_storage(force_migrate=True)
+    storage.init_storage(force_migrate=True, recreate_materialized_views=args.materialized_views)
 else:
     storage.init_storage()
     params = {

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -93,7 +93,7 @@ class GOBStorageHandler():
         self.metadata = gob_metadata
         self.session = None
 
-    def init_storage(self, force_migrate=False):
+    def init_storage(self, force_migrate=False, recreate_materialized_views=False):
         """Check if the necessary tables (for events, and for the entities in gobmodel) are present
         If not, they are required
         """
@@ -137,7 +137,7 @@ class GOBStorageHandler():
         self._init_indexes()
 
         # Initialise materialized views for relations
-        self._init_relation_materialized_views()
+        self._init_relation_materialized_views(recreate_materialized_views)
 
     def _init_views(self):
         """
@@ -169,9 +169,9 @@ class GOBStorageHandler():
         for statement in statements:
             self.execute(statement)
 
-    def _init_relation_materialized_views(self):
+    def _init_relation_materialized_views(self, recreate=False):
         mv = MaterializedViews()
-        mv.initialise(self)
+        mv.initialise(self, recreate)
 
     def _get_index_type(self, type: str) -> str:
         if type == "geo":

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.9.18#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.9.20#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -81,20 +81,26 @@ class TestStorageHandler(unittest.TestCase):
         self.storage._set_base = MagicMock()
         self.storage._init_relation_materialized_views = MagicMock()
 
-        self.storage.init_storage()
+        self.storage.init_storage(recreate_materialized_views='booleanValue')
         # mock_alembic.config.main.assert_called_once()
 
         self.storage._init_views.assert_called_once()
         # self.storage._set_base.assert_called_with(update=True)
         self.storage._init_indexes.assert_called_once()
-        self.storage._init_relation_materialized_views.assert_called_once()
+        self.storage._init_relation_materialized_views.assert_called_with('booleanValue')
 
     @patch("gobupload.storage.handler.MaterializedViews")
     def test_init_relation_materialized_view(self, mock_materialized_views):
         self.storage._init_relation_materialized_views()
 
         mock_materialized_views.assert_called_once()
-        mock_materialized_views.return_value.initialise.assert_called_with(self.storage)
+        mock_materialized_views.return_value.initialise.assert_called_with(self.storage, False)
+
+        mock_materialized_views.reset_mock()
+        self.storage._init_relation_materialized_views(True)
+
+        mock_materialized_views.assert_called_once()
+        mock_materialized_views.return_value.initialise.assert_called_with(self.storage, True)
 
     def test_indexes_to_drop_query(self):
         expected = """

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -37,4 +37,21 @@ class TestMain(TestCase):
         importlib.reload(__main__)
 
         mock_service.return_value.start.assert_not_called()
-        mock_storage.return_value.init_storage.assert_called_with(force_migrate=True)
+        mock_storage.return_value.init_storage.assert_called_with(
+            force_migrate=True,
+            recreate_materialized_views=False
+        )
+
+    @mock.patch('gobupload.storage.handler.GOBStorageHandler')
+    @mock.patch('gobcore.message_broker.messagedriven_service.MessagedrivenService')
+    def test_main_calls_migrate_materialized_views(self, mock_service, mock_storage):
+        # With migrate command line arguments
+        sys.argv = ['python -m gobupload', '--migrate', '--materialized_views']
+        from gobupload import __main__
+        importlib.reload(__main__)
+
+        mock_service.return_value.start.assert_not_called()
+        mock_storage.return_value.init_storage.assert_called_with(
+            force_migrate=True,
+            recreate_materialized_views=True
+        )


### PR DESCRIPTION
Add functionality to force recreation of materialized views and indexes.
Update gobcore.

This PR can be merged without worrying about forcing recreation of materialized views. This has already been done on acc (from my local machine).