### PR TITLE
Highway to...

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -1,5 +1,6 @@
 from gobcore.logging.logger import logger
 from gobcore.utils import ProgressTicker
+from gobcore.message_broker.offline_contents import ContentsReader
 
 from gobupload.storage.handler import GOBStorageHandler
 from gobupload.update.update_statistics import UpdateStatistics
@@ -27,11 +28,19 @@ def apply_events(storage, last_events, start_after, stats):
                 action, count = event_applicator.apply(event)
                 stats.add_applied(action, count)
 
-    with ActiveGarbageCollection("Delete any confirm events"), storage.get_session():
-        logger.info(f"Post-process any CONFIRM events")
 
-        # Confirms are deleted once they have been applied
-        storage.delete_confirms()
+def apply_confirm_events(storage, stats, msg):
+    confirms = msg.get('confirms')
+    if confirms:
+        reader = ContentsReader(confirms)
+        with ProgressTicker("Apply CONFIRM events", 10000) as progress:
+            for event in reader.items():
+                progress.tick()
+                action = event['event']
+                confirms = event['data'].get('confirms', [event['data']])
+                storage.apply_confirms(confirms, msg['header']['timestamp'])
+                stats.add_applied(action, len(confirms))
+        reader.close()
 
 
 def apply(msg):
@@ -45,6 +54,8 @@ def apply(msg):
     combinations = storage.get_source_catalogue_entity_combinations(catalogue=catalogue, entity=entity)
 
     for result in combinations:
+        # Gather statistics of update process
+        stats = UpdateStatistics()
         model = f"{result.source} {result.catalogue} {result.entity}"
         storage = GOBStorageHandler(result)
         entity_max_eventid, last_eventid = get_event_ids(storage)
@@ -52,39 +63,20 @@ def apply(msg):
             logger.error(f"Model {model} is inconsistent! data is more recent than events")
         elif entity_max_eventid == last_eventid:
             logger.info(f"Model {model} is up to date")
-            # # Apply confirms
-            # print("APPLY", msg)
-            # # for entity in msg.get("contents", []):
-            # #     print(entity)
+            apply_confirm_events(storage, stats, msg)
         else:
             logger.info(f"Start application of unhandled {model} events")
             with storage.get_session():
                 last_events = storage.get_last_events()  # { source_id: last_event, ... }
 
-            # Gather statistics of update process
-            stats = UpdateStatistics()
-
             apply_events(storage, last_events, entity_max_eventid, stats)
+            apply_confirm_events(storage, stats, msg)
 
-            # Build result message
-            results = stats.results()
+        # Build result message
+        results = stats.results()
 
-            # # Apply confirms
-            # print("APPLY", msg.get("contents"))
-            # # for entity in msg.get("contents", []):
-            # #     print(entity)
-
-            stats.log()
-            logger.info(f"Update model {model} completed", {'data': results})
-
-    # return {
-    #     'header': msg['header'],
-    #     'summary': {
-    #         'warnings': logger.get_warnings(),
-    #         'errors': logger.get_errors()
-    #     },
-    #     'contents': []
-    # }
+        stats.log()
+        logger.info(f"Update model {model} completed", {'data': results})
 
     msg['summary'] = {
         'warnings': logger.get_warnings(),

--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -52,6 +52,10 @@ def apply(msg):
             logger.error(f"Model {model} is inconsistent! data is more recent than events")
         elif entity_max_eventid == last_eventid:
             logger.info(f"Model {model} is up to date")
+            # # Apply confirms
+            # print("APPLY", msg)
+            # # for entity in msg.get("contents", []):
+            # #     print(entity)
         else:
             logger.info(f"Start application of unhandled {model} events")
             with storage.get_session():
@@ -65,8 +69,22 @@ def apply(msg):
             # Build result message
             results = stats.results()
 
+            # # Apply confirms
+            # print("APPLY", msg.get("contents"))
+            # # for entity in msg.get("contents", []):
+            # #     print(entity)
+
             stats.log()
             logger.info(f"Update model {model} completed", {'data': results})
+
+    # return {
+    #     'header': msg['header'],
+    #     'summary': {
+    #         'warnings': logger.get_warnings(),
+    #         'errors': logger.get_errors()
+    #     },
+    #     'contents': []
+    # }
 
     msg['summary'] = {
         'warnings': logger.get_warnings(),

--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -50,9 +50,10 @@ def apply_confirm_events(storage, stats, msg):
             for event in reader.items():
                 progress.tick()
                 action = event['event']
+                assert action in ['CONFIRM', 'BULKCONFIRM']
                 # get confirm data: BULKCONFIRM => data.confirms, CONFIRM => [data]
-                confirms = event['data'].get('confirms', [event['data']])
-                storage.apply_confirms(confirms, msg['header']['timestamp'])
+                confirm_data = event['data'].get('confirms', [event['data']])
+                storage.apply_confirms(confirm_data, msg['header']['timestamp'])
                 stats.add_applied(action, len(confirms))
         reader.close()
         # Remove file after it has been handled

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -662,7 +662,7 @@ WHERE
         :return:
         """
         source_ids = [record['_source_id'] for record in confirms]
-        stmt = update(self.DbEntity).where(self.DbEntity._source_id.in_(source_ids)). \
+        stmt = update(self.DbEntity).where(self.DbEntity._source_id.in_(source_ids)).\
             values({CONFIRM.timestamp_field: timestamp})
         self.execute(stmt)
 

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -651,12 +651,16 @@ WHERE
         :param eventid: the id of the event to store as _last_event
         :return:
         """
-        source_ids = [record['_source_id'] for record in event._data['confirms']]
-        stmt = update(self.DbEntity).where(self.DbEntity._source_id.in_(source_ids)).\
-            values({event.timestamp_field: event._metadata.timestamp})
-        self.execute(stmt)
+        self.apply_confirms(event._data['confirms'], event._metadata.timestamp)
 
     def apply_confirms(self, confirms, timestamp):
+        """
+        Apply a (BULK)CONFIRM event
+
+        :param confirms: list of confirm data
+        :param timestamp: Time to set as last_confirmed
+        :return:
+        """
         source_ids = [record['_source_id'] for record in confirms]
         stmt = update(self.DbEntity).where(self.DbEntity._source_id.in_(source_ids)). \
             values({CONFIRM.timestamp_field: timestamp})

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -28,6 +28,7 @@ from gobcore.typesystem.json import GobTypeJSONEncoder
 from gobcore.views import GOBViews
 from gobcore.utils import ProgressTicker
 from sqlalchemy.orm.exc import MultipleResultsFound
+from gobcore.events.import_events import CONFIRM
 
 from gobupload.config import GOB_DB, FULL_UPLOAD
 from gobupload.storage import queries
@@ -653,6 +654,12 @@ WHERE
         source_ids = [record['_source_id'] for record in event._data['confirms']]
         stmt = update(self.DbEntity).where(self.DbEntity._source_id.in_(source_ids)).\
             values({event.timestamp_field: event._metadata.timestamp})
+        self.execute(stmt)
+
+    def apply_confirms(self, confirms, timestamp):
+        source_ids = [record['_source_id'] for record in confirms]
+        stmt = update(self.DbEntity).where(self.DbEntity._source_id.in_(source_ids)). \
+            values({CONFIRM.timestamp_field: timestamp})
         self.execute(stmt)
 
     def bulk_insert(self, table, insert_data):

--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -36,19 +36,16 @@ def _store_events(storage, last_events, events, stats):
             for event in events:
                 progress.tick()
 
-                # print("EVENT", event['event'])
-                #
-                # if event['event'] in ['CONFIRM', 'BULKCONFIRM']:
-                #     print("Skip confirm")
-                #     writer.write(event)
-                #     continue
+                if event['event'] in ['CONFIRM', 'BULKCONFIRM']:
+                    writer.write(event)
+                    continue
 
                 if event_collector.collect(event):
                     stats.store_event(event)
                 else:
                     stats.skip_event(event)
 
-        # return filename
+        return filename
 
 
 def _process_events(storage, events, stats):
@@ -113,12 +110,9 @@ def full_update(msg):
     # Return the result message, with no log, no contents
     message = {
         "header": msg["header"],
-        "summary": results
+        "summary": results,
+        "contents": None
     }
     if filename:
-        print("WRITE CONTENTS", filename)
-        message['contents_ref'] = filename
-    else:
-        print("NO CONTENTS")
-        message['contents'] = None
+        message['confirms'] = filename
     return message

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -44,7 +44,7 @@ class TestApply(TestCase):
     @patch('gobupload.apply.main.apply_events')
     def test_apply_none(self, mock_apply, mock):
         mock.return_value = self.mock_storage
-        # self.mock_storage.get_source_catalogue_entity_combinations.return_value = []
+        self.mock_storage.get_source_catalogue_entity_combinations.return_value = []
 
         result = apply({'header': {}})
 

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -3,7 +3,7 @@ import logging
 from unittest import TestCase
 from unittest.mock import MagicMock, patch, ANY
 
-from gobupload.apply.main import apply_events, apply
+from gobupload.apply.main import apply_events, apply_confirm_events, apply
 from gobupload.storage.handler import GOBStorageHandler
 from tests import fixtures
 
@@ -64,6 +64,69 @@ class TestApply(TestCase):
 
         self.assertEqual(result, {'header': {}, 'summary': {'errors': ANY, 'warnings': ANY}})
         mock_apply.assert_called()
+
+    @patch('gobupload.apply.main.os')
+    @patch('gobupload.apply.main.ContentsReader')
+    def test_apply_confirm_events(self, mock_contents_reader, mock_os, mock):
+        mock_stats = MagicMock()
+        mock_reader = MagicMock()
+        mock_contents_reader.return_value = mock_reader
+
+        msg = {
+            'header': {
+                'timestamp': 'any timestamp'
+            },
+            'confirms': 'any filename'
+        }
+
+        # Bulkconfirm
+        items = [
+            {
+                'event': 'BULKCONFIRM',
+                'data': {
+                    'confirms': 'any confirms'
+                }
+            }
+        ]
+
+        mock_reader.items.return_value = items
+        apply_confirm_events(self.mock_storage, mock_stats, msg)
+
+        self.mock_storage.apply_confirms.assert_called_with('any confirms', 'any timestamp')
+        mock_os.remove.assert_called_with('any filename')
+
+        # put CONFIRM data in a list
+        items = [
+            {
+                'event': 'CONFIRM',
+                'data': {'some key': 'any data'}
+            }
+        ]
+
+        mock_reader.items.return_value = items
+        apply_confirm_events(self.mock_storage, mock_stats, msg)
+
+        self.mock_storage.apply_confirms.assert_called_with([{'some key': 'any data'}], 'any timestamp')
+
+        # Assert that only (BULK)CONFIRMS are handled
+        items = [
+            {
+                'event': 'some other event'
+            }
+        ]
+        mock_reader.items.return_value = items
+        with self.assertRaises(AssertionError):
+            apply_confirm_events(self.mock_storage, mock_stats, msg)
+
+        # Only execute if msg has confirms
+        mock_os.remove.reset_mock()
+        msg = {
+        }
+        apply_confirm_events(self.mock_storage, mock_stats, msg)
+        mock_os.remove.assert_not_called()
+
+
+
 
     @patch('gobupload.apply.main.logger', MagicMock())
     @patch('gobupload.apply.main.get_event_ids', lambda s: (2, 1))

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -44,13 +44,14 @@ class TestApply(TestCase):
     @patch('gobupload.apply.main.apply_events')
     def test_apply_none(self, mock_apply, mock):
         mock.return_value = self.mock_storage
-        self.mock_storage.get_source_catalogue_entity_combinations.return_value = []
+        # self.mock_storage.get_source_catalogue_entity_combinations.return_value = []
 
         result = apply({'header': {}})
 
         self.assertEqual(result, {'header': {}, 'summary': {'errors': ANY, 'warnings': ANY}})
         mock_apply.assert_not_called()
 
+    @patch('gobupload.apply.main.ContentsReader', MagicMock())
     @patch('gobupload.apply.main.logger', MagicMock())
     @patch('gobupload.apply.main.get_event_ids', lambda s: (1, 2))
     @patch('gobupload.apply.main.apply_events')
@@ -77,6 +78,7 @@ class TestApply(TestCase):
         self.assertEqual(result, {'header': {}, 'summary': {'errors': ANY, 'warnings': ANY}})
         mock_apply.assert_not_called()
 
+    @patch('gobupload.apply.main.ContentsReader', MagicMock())
     @patch('gobupload.apply.main.logger', MagicMock())
     @patch('gobupload.apply.main.get_event_ids', lambda s: (1, 1))
     @patch('gobupload.apply.main.apply_events')

--- a/src/tests/test_update.py
+++ b/src/tests/test_update.py
@@ -172,3 +172,38 @@ class TestUpdate(TestCase):
         stats = UpdateStatistics()
 
         _store_events(self.mock_storage, last_events, [event], stats)
+
+    @patch('gobupload.update.main.EventCollector')
+    @patch('gobupload.update.main.ContentsWriter')
+    def test_store_events_with_confirms(self, mock_contents_writer, mock_event_collector, mock):
+        mock_with_writer = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.filename = 'any filename'
+        mock_with_writer = MagicMock()
+        mock_with_writer.__enter__.return_value = mock_writer
+        mock_contents_writer.return_value = mock_with_writer
+
+        mock_collector = MagicMock()
+        mock_with_collector = MagicMock()
+        mock_with_collector.__enter__.return_value = mock_collector
+        mock_event_collector.return_value = mock_with_collector
+
+        events = [
+            {
+                'event': 'CONFIRM'
+            },
+            {
+                'event': 'BULKCONFIRM'
+            },
+            {
+                'event': 'some other event'
+            }
+        ]
+
+        result = _store_events(self.mock_storage, 'some last events', events, MagicMock())
+        self.assertEqual(result, 'any filename')
+
+        self.assertEqual(mock_writer.write.call_count, 2)
+        mock_writer.write.assert_called_with({'event': 'BULKCONFIRM'})
+        self.assertEqual(mock_collector.collect.call_count, 1)
+        mock_collector.collect.assert_called_with({'event': 'some other event'})

--- a/src/tests/test_update.py
+++ b/src/tests/test_update.py
@@ -14,7 +14,6 @@ from gobupload.update.event_applicator import _get_gob_event
 from gobupload.storage.handler import GOBStorageHandler
 from tests import fixtures
 
-
 @patch('gobupload.update.main.GOBStorageHandler')
 class TestUpdate(TestCase):
     def setUp(self):
@@ -35,6 +34,7 @@ class TestUpdate(TestCase):
         self.assertEqual(max_id, "max")
         self.assertEqual(last_id, "last")
 
+    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.main.get_event_ids')
     def test_fullupdate_saves_event(self, mock_ids, mock):
         self.mock_storage.get_last_events.return_value = {}
@@ -44,8 +44,9 @@ class TestUpdate(TestCase):
         message = fixtures.get_event_message_fixture()
         full_update(message)
 
-        self.mock_storage.add_events.assert_called_with(message['contents'])
+        # self.mock_storage.add_events.assert_called_with(message['contents'])
 
+    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main.get_event_ids')
     def test_fullupdate_creates_event_and_pops_ids(self, mock_ids, mock_event, mock):
@@ -61,10 +62,10 @@ class TestUpdate(TestCase):
 
         self.mock_storage.get_events_starting_after.return_value = []
 
-        full_update(message)
+        result = full_update(message)
 
-        self.mock_storage.add_events.assert_called()
         self.mock_storage.get_events_starting_after.assert_not_called()
+        self.assertIsNotNone(result['confirms'], "")
 
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main.get_event_ids')
@@ -85,6 +86,7 @@ class TestUpdate(TestCase):
         self.mock_storage.add_events.assert_not_called()
         self.mock_storage.get_events_starting_after.assert_not_called()
 
+    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main.get_event_ids')
     def test_fullupdate_applies_events(self, mock_ids, mock_event, mock):
@@ -158,6 +160,7 @@ class TestUpdate(TestCase):
             # Assert that Exception is thrown when events have invalid actions
             self.assertRaises(GOBException, _get_gob_event, dummy_event, {})
 
+    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     def test_store_events(self, mock):
         metadata = fixtures.get_metadata_fixture()
         event = fixtures.get_event_fixture(metadata)

--- a/src/tests/test_update.py
+++ b/src/tests/test_update.py
@@ -14,6 +14,7 @@ from gobupload.update.event_applicator import _get_gob_event
 from gobupload.storage.handler import GOBStorageHandler
 from tests import fixtures
 
+
 @patch('gobupload.update.main.GOBStorageHandler')
 class TestUpdate(TestCase):
     def setUp(self):
@@ -44,7 +45,7 @@ class TestUpdate(TestCase):
         message = fixtures.get_event_message_fixture()
         full_update(message)
 
-        # self.mock_storage.add_events.assert_called_with(message['contents'])
+        self.mock_storage.add_events.assert_called_with(message['contents'])
 
     @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.event_applicator.GobEvent')


### PR DESCRIPTION
Fast processing of (BULK)CONFIRM events.

While storing the events (fullupdate) the CONFIRM events are not stored in the events table but in a file.

When applying events (apply) the regular events are processed. When everything is OK the CONFIRM events from the file are processed (just setting the last confirmed timestamp).

The handling of CONFIRM events has become must faster but also the events table stays cleaner. No eventid's are used for CONFIRM events and no CONFIRM events get stored and later deleted in the events table.