### PR TITLE
Let compare write confirm events directly in a confirms file

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -54,7 +54,7 @@ def apply_confirm_events(storage, stats, msg):
                 # get confirm data: BULKCONFIRM => data.confirms, CONFIRM => [data]
                 confirm_data = event['data'].get('confirms', [event['data']])
                 storage.apply_confirms(confirm_data, msg['header']['timestamp'])
-                stats.add_applied(action, len(confirms))
+                stats.add_applied('CONFIRM', len(confirm_data))
         reader.close()
         # Remove file after it has been handled
         os.remove(confirms)

--- a/src/gobupload/compare/event_collector.py
+++ b/src/gobupload/compare/event_collector.py
@@ -11,7 +11,7 @@ class EventCollector:
     MAX_BULK = 10000          # Max number of events of same type in one bulk event
     BULK_TYPES = ["CONFIRM"]  # Only CONFIRM events are grouped in bulk events
 
-    def __init__(self, contents_writer):
+    def __init__(self, contents_writer, confirms_writer):
         """
         Initializes the collector with empty collections
 
@@ -19,6 +19,7 @@ class EventCollector:
         self._bulk_events = []
         self._last_type = None
         self.contents_writer = contents_writer
+        self.confirms_writer = confirms_writer
 
     def __enter__(self):
         return self
@@ -36,7 +37,10 @@ class EventCollector:
         :param event:
         :return:
         """
-        self.contents_writer.write(event)
+        if event['event'] in ['CONFIRM', 'BULKCONFIRM']:
+            self.confirms_writer.write(event)
+        else:
+            self.contents_writer.write(event)
 
     def _add_bulk_event(self, event):
         """

--- a/src/tests/compare/test_event_collector.py
+++ b/src/tests/compare/test_event_collector.py
@@ -5,29 +5,31 @@ from gobcore.message_broker.offline_contents import ContentsWriter
 from gobupload.compare.event_collector import EventCollector
 
 mock_writer = MagicMock(spec=ContentsWriter)
+mock_confirms_writer = MagicMock(spec=ContentsWriter)
 
 @patch('gobupload.compare.main.ContentsWriter', mock_writer)
 class TestEventCollector(TestCase):
 
     def setUp(self):
         mock_writer.reset_mock()
+        mock_confirms_writer.reset_mock()
 
     def tearDown(self):
         pass
 
     def test_add_empty(self):
-        with EventCollector(mock_writer) as ec:
+        with EventCollector(mock_writer, mock_confirms_writer) as ec:
             pass
         mock_writer.assert_not_called()
 
     def test_add_one(self):
-        with EventCollector(mock_writer) as ec:
+        with EventCollector(mock_writer, mock_confirms_writer) as ec:
             ec.collect({"event": 1})
         mock_writer.write.assert_called_once()
         mock_writer.write.assert_called_with({"event": 1})
 
     def test_add_multiple(self):
-        with EventCollector(mock_writer) as ec:
+        with EventCollector(mock_writer, mock_confirms_writer) as ec:
             ec.collect({"event": 1})
             mock_writer.write.assert_called_with({"event": 1})
             ec.collect({"event": 2})
@@ -44,10 +46,11 @@ class TestEventCollector(TestCase):
             }
         }
 
-        with EventCollector(mock_writer) as ec:
+        with EventCollector(mock_writer, mock_confirms_writer) as ec:
             ec.collect(confirm_event)
-        mock_writer.write.assert_called_once()
-        mock_writer.write.assert_called_with(confirm_event)
+        mock_writer.write.assert_not_called()
+        mock_confirms_writer.write.assert_called_once()
+        mock_confirms_writer.write.assert_called_with(confirm_event)
 
     def test_add_bulk_multi(self):
         confirm_event = {
@@ -69,18 +72,19 @@ class TestEventCollector(TestCase):
             }
         }
 
-        with EventCollector(mock_writer) as ec:
+        with EventCollector(mock_writer, mock_confirms_writer) as ec:
             ec.collect(confirm_event)
             ec.collect(confirm_event)
-        mock_writer.write.assert_called_once()
-        mock_writer.write.assert_called_with(expectation)
+        mock_writer.write.assert_not_called()
+        mock_confirms_writer.write.assert_called_once()
+        mock_confirms_writer.write.assert_called_with(expectation)
 
         mock_writer.reset_mock()
 
         EventCollector.MAX_BULK = 2
-        with EventCollector(mock_writer) as ec:
+        with EventCollector(mock_writer, mock_confirms_writer) as ec:
             ec.collect(confirm_event)
             ec.collect(confirm_event)
-            mock_writer.write.assert_called_with(expectation)
+            mock_confirms_writer.write.assert_called_with(expectation)
             ec.collect(confirm_event)
-        mock_writer.write.assert_called_with(confirm_event)
+        mock_confirms_writer.write.assert_called_with(confirm_event)

--- a/src/tests/compare/test_event_collector.py
+++ b/src/tests/compare/test_event_collector.py
@@ -4,38 +4,38 @@ from unittest.mock import MagicMock, patch
 from gobcore.message_broker.offline_contents import ContentsWriter
 from gobupload.compare.event_collector import EventCollector
 
-mock_writer = MagicMock(spec=ContentsWriter)
+mock_contents_writer = MagicMock(spec=ContentsWriter)
 mock_confirms_writer = MagicMock(spec=ContentsWriter)
 
-@patch('gobupload.compare.main.ContentsWriter', mock_writer)
+@patch('gobupload.compare.main.ContentsWriter', mock_contents_writer)
 class TestEventCollector(TestCase):
 
     def setUp(self):
-        mock_writer.reset_mock()
+        mock_contents_writer.reset_mock()
         mock_confirms_writer.reset_mock()
 
     def tearDown(self):
         pass
 
     def test_add_empty(self):
-        with EventCollector(mock_writer, mock_confirms_writer) as ec:
+        with EventCollector(mock_contents_writer, mock_confirms_writer) as ec:
             pass
-        mock_writer.assert_not_called()
+        mock_contents_writer.assert_not_called()
 
     def test_add_one(self):
-        with EventCollector(mock_writer, mock_confirms_writer) as ec:
+        with EventCollector(mock_contents_writer, mock_confirms_writer) as ec:
             ec.collect({"event": 1})
-        mock_writer.write.assert_called_once()
-        mock_writer.write.assert_called_with({"event": 1})
+        mock_contents_writer.write.assert_called_once()
+        mock_contents_writer.write.assert_called_with({"event": 1})
 
     def test_add_multiple(self):
-        with EventCollector(mock_writer, mock_confirms_writer) as ec:
+        with EventCollector(mock_contents_writer, mock_confirms_writer) as ec:
             ec.collect({"event": 1})
-            mock_writer.write.assert_called_with({"event": 1})
+            mock_contents_writer.write.assert_called_with({"event": 1})
             ec.collect({"event": 2})
-            mock_writer.write.assert_called_with({"event": 2})
+            mock_contents_writer.write.assert_called_with({"event": 2})
             ec.collect({"event": 3})
-            mock_writer.write.assert_called_with({"event": 3})
+            mock_contents_writer.write.assert_called_with({"event": 3})
 
     def test_add_bulk_one(self):
         confirm_event = {
@@ -46,9 +46,9 @@ class TestEventCollector(TestCase):
             }
         }
 
-        with EventCollector(mock_writer, mock_confirms_writer) as ec:
+        with EventCollector(mock_contents_writer, mock_confirms_writer) as ec:
             ec.collect(confirm_event)
-        mock_writer.write.assert_not_called()
+        mock_contents_writer.write.assert_not_called()
         mock_confirms_writer.write.assert_called_once()
         mock_confirms_writer.write.assert_called_with(confirm_event)
 
@@ -72,17 +72,17 @@ class TestEventCollector(TestCase):
             }
         }
 
-        with EventCollector(mock_writer, mock_confirms_writer) as ec:
+        with EventCollector(mock_contents_writer, mock_confirms_writer) as ec:
             ec.collect(confirm_event)
             ec.collect(confirm_event)
-        mock_writer.write.assert_not_called()
+        mock_contents_writer.write.assert_not_called()
         mock_confirms_writer.write.assert_called_once()
         mock_confirms_writer.write.assert_called_with(expectation)
 
-        mock_writer.reset_mock()
+        mock_contents_writer.reset_mock()
 
         EventCollector.MAX_BULK = 2
-        with EventCollector(mock_writer, mock_confirms_writer) as ec:
+        with EventCollector(mock_contents_writer, mock_confirms_writer) as ec:
             ec.collect(confirm_event)
             ec.collect(confirm_event)
             mock_confirms_writer.write.assert_called_with(expectation)

--- a/src/tests/test_update.py
+++ b/src/tests/test_update.py
@@ -168,3 +168,4 @@ class TestUpdate(TestCase):
         stats = UpdateStatistics()
 
         _store_events(self.mock_storage, last_events, [event], stats)
+

--- a/src/tests/test_update.py
+++ b/src/tests/test_update.py
@@ -35,7 +35,6 @@ class TestUpdate(TestCase):
         self.assertEqual(max_id, "max")
         self.assertEqual(last_id, "last")
 
-    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.main.get_event_ids')
     def test_fullupdate_saves_event(self, mock_ids, mock):
         self.mock_storage.get_last_events.return_value = {}
@@ -47,7 +46,6 @@ class TestUpdate(TestCase):
 
         self.mock_storage.add_events.assert_called_with(message['contents'])
 
-    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main.get_event_ids')
     def test_fullupdate_creates_event_and_pops_ids(self, mock_ids, mock_event, mock):
@@ -66,7 +64,6 @@ class TestUpdate(TestCase):
         result = full_update(message)
 
         self.mock_storage.get_events_starting_after.assert_not_called()
-        self.assertIsNotNone(result['confirms'], "")
 
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main.get_event_ids')
@@ -87,7 +84,6 @@ class TestUpdate(TestCase):
         self.mock_storage.add_events.assert_not_called()
         self.mock_storage.get_events_starting_after.assert_not_called()
 
-    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     @patch('gobupload.update.event_applicator.GobEvent')
     @patch('gobupload.update.main.get_event_ids')
     def test_fullupdate_applies_events(self, mock_ids, mock_event, mock):
@@ -161,7 +157,6 @@ class TestUpdate(TestCase):
             # Assert that Exception is thrown when events have invalid actions
             self.assertRaises(GOBException, _get_gob_event, dummy_event, {})
 
-    @patch('gobupload.update.main.ContentsWriter', MagicMock())
     def test_store_events(self, mock):
         metadata = fixtures.get_metadata_fixture()
         event = fixtures.get_event_fixture(metadata)
@@ -173,38 +168,3 @@ class TestUpdate(TestCase):
         stats = UpdateStatistics()
 
         _store_events(self.mock_storage, last_events, [event], stats)
-
-    @patch('gobupload.update.main.EventCollector')
-    @patch('gobupload.update.main.ContentsWriter')
-    def test_store_events_with_confirms(self, mock_contents_writer, mock_event_collector, mock):
-        mock_with_writer = MagicMock()
-        mock_writer = MagicMock()
-        mock_writer.filename = 'any filename'
-        mock_with_writer = MagicMock()
-        mock_with_writer.__enter__.return_value = mock_writer
-        mock_contents_writer.return_value = mock_with_writer
-
-        mock_collector = MagicMock()
-        mock_with_collector = MagicMock()
-        mock_with_collector.__enter__.return_value = mock_collector
-        mock_event_collector.return_value = mock_with_collector
-
-        events = [
-            {
-                'event': 'CONFIRM'
-            },
-            {
-                'event': 'BULKCONFIRM'
-            },
-            {
-                'event': 'some other event'
-            }
-        ]
-
-        result = _store_events(self.mock_storage, 'some last events', events, MagicMock())
-        self.assertEqual(result, 'any filename')
-
-        self.assertEqual(mock_writer.write.call_count, 2)
-        mock_writer.write.assert_called_with({'event': 'BULKCONFIRM'})
-        self.assertEqual(mock_collector.collect.call_count, 1)
-        mock_collector.collect.assert_called_with({'event': 'some other event'})


### PR DESCRIPTION
This eliminates the need to write confirm events twice:
- in the events file by compare
- in the confirms file by fullupdate