### PR TITLE
Re-enable indexes on materialized views

### DIFF
--- a/src/gobupload/storage/materialized_views.py
+++ b/src/gobupload/storage/materialized_views.py
@@ -97,9 +97,8 @@ class MaterializedView:
             if force_recreate:
                 storage_handler.execute(f"DROP INDEX IF EXISTS {index_name}")
 
-            # Temporary disable
-            # query = f"CREATE INDEX IF NOT EXISTS {index_name} ON {self.name}({','.join(columns)})"
-            # storage_handler.execute(query)
+            query = f"CREATE INDEX IF NOT EXISTS {index_name} ON {self.name}({','.join(columns)})"
+            storage_handler.execute(query)
 
 
 class MaterializedViews:

--- a/src/tests/storage/test_materialized_views.py
+++ b/src/tests/storage/test_materialized_views.py
@@ -95,13 +95,13 @@ class TestMaterializedView(TestCase):
         self.mv.src_has_states = True
         self.mv._create_indexes(storage_handler)
 
-        # storage_handler.execute.assert_has_calls([
-        #     call(f"CREATE INDEX IF NOT EXISTS src_id_{self.mv.name} ON {self.mv.name}(src_id)"),
-        #     call(f"CREATE INDEX IF NOT EXISTS dst_id_{self.mv.name} ON {self.mv.name}(dst_id)"),
-        #     call(f"CREATE INDEX IF NOT EXISTS gobid_{self.mv.name} ON {self.mv.name}(_gobid)"),
-        #     call(f"CREATE INDEX IF NOT EXISTS src_dst_wide_{self.mv.name} ON "
-        #          f"{self.mv.name}(src_id,src_volgnummer,dst_id,dst_volgnummer)")
-        # ])
+        storage_handler.execute.assert_has_calls([
+            call(f"CREATE INDEX IF NOT EXISTS src_id_{self.mv.name} ON {self.mv.name}(src_id)"),
+            call(f"CREATE INDEX IF NOT EXISTS dst_id_{self.mv.name} ON {self.mv.name}(dst_id)"),
+            call(f"CREATE INDEX IF NOT EXISTS gobid_{self.mv.name} ON {self.mv.name}(_gobid)"),
+            call(f"CREATE INDEX IF NOT EXISTS src_dst_wide_{self.mv.name} ON "
+                 f"{self.mv.name}(src_id,src_volgnummer,dst_id,dst_volgnummer)")
+        ])
 
 
 @patch("gobupload.storage.materialized_views.GOBModel", MagicMock())


### PR DESCRIPTION
The functionality was disabled beacuse it lead to errors on the ACC environment
These errors have been fixed, so the functionality can be re-enabled