### PR TITLE
Fill entity with the collection instead of catalog

### DIFF
--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -158,7 +158,7 @@ def build_relations(msg):
         "version": "0.1",
         "source": "GOB",
         "application": application,
-        "entity": catalog_name
+        "entity": collection_name
     }
 
     timestamp = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
For relate jobs this resulted in a log record with ‘nap’ as both the catalog and collection which caused the frontend to try to start a relate job with ‘relate nap nap’ resulting in an error. When a job is started with only a catalog the collection will be NULL in the database