### PR TITLE
Partitioned events table

### DIFF
--- a/src/alembic/env.py
+++ b/src/alembic/env.py
@@ -32,8 +32,9 @@ target_metadata = Base.metadata
 
 
 def include_object(object, name, type_, reflected, compare_to):
-    if type_ == "index" or name == "spatial_ref_sys":
+    if type_ == "index" or name in ["spatial_ref_sys", "events"]:
         # Indexes are created by gobupload upon startup
+        # Events is a partitioned table and is maintained manually
         return False
     else:
         return True

--- a/src/alembic/versions/ea556acbed92_events_partitioning.py
+++ b/src/alembic/versions/ea556acbed92_events_partitioning.py
@@ -1,7 +1,7 @@
 """events partitioning
 
 Revision ID: ea556acbed92
-Revises: 030c8d16a3be
+Revises: d53cfff60616
 Create Date: 2020-02-20 18:33:18.110196
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = 'ea556acbed92'
-down_revision = '030c8d16a3be'
+down_revision = 'd53cfff60616'
 branch_labels = None
 depends_on = None
 

--- a/src/alembic/versions/ea556acbed92_events_partitioning.py
+++ b/src/alembic/versions/ea556acbed92_events_partitioning.py
@@ -1,0 +1,156 @@
+"""events partitioning
+
+Revision ID: ea556acbed92
+Revises: 030c8d16a3be
+Create Date: 2020-02-20 18:33:18.110196
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'ea556acbed92'
+down_revision = '030c8d16a3be'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+-- Save existing events by renaming events table
+ALTER TABLE events RENAME TO events_org;
+
+-- Create new partitioned events table
+CREATE TABLE public.events (
+	eventid     SERIAL    NOT NULL,
+	"timestamp" TIMESTAMP NOT NULL,
+	catalogue   VARCHAR   NOT NULL,
+	entity      VARCHAR   NOT NULL,
+	"version"   VARCHAR   NOT NULL,
+	"action"    VARCHAR   NOT NULL,
+	"source"    VARCHAR   NOT NULL,
+	source_id   VARCHAR   NOT NULL,
+	contents    JSONB     NOT NULL,
+	application VARCHAR   NOT NULL,
+	-- Primary keys are supported on partitioned tables, foreign keys referencing partitioned tables are not supported.
+	PRIMARY KEY (eventid, catalogue, entity),
+	-- Unique constraints on partitioned tables must include all the partition key columns
+	CONSTRAINT events_eventid_catalogue_entity UNIQUE (eventid, catalogue, entity)
+) PARTITION BY LIST (catalogue);
+
+-- Create events partitions in a separate schema
+DROP SCHEMA IF EXISTS events_parts CASCADE;
+CREATE SCHEMA         events_parts;
+
+-- Create a function to automatically create partitions and insert new events
+DROP FUNCTION IF EXISTS insertIntoEventsPartition CASCADE;
+CREATE FUNCTION         insertIntoEventsPartition (
+	ev RECORD
+)
+RETURNS VOID
+AS
+$body$
+DECLARE
+    schema_name TEXT;
+    cat_part    TEXT;
+    ent_part    TEXT;
+BEGIN
+	-- Construct catalogue and entity parttion table names
+	schema_name := 'events_parts';
+	-- catalogue partition: event_parts.events_catalogue
+    cat_part    := schema_name || '.events_' || ev.catalogue;
+	-- entity partition:    event_parts.events_catalogue_entity
+    ent_part    := cat_part || '_' || ev.entity;
+   
+	-- Create catalogue partition if not yet exists
+    IF to_regclass(cat_part) IS NULL THEN
+    	-- CREATE TABLE cat_part PARTITION OF events FOR VALUES IN (catalogue) PARTITION BY LIST (entity)
+		EXECUTE 'CREATE TABLE ' ||
+		        cat_part ||
+		        ' PARTITION OF events FOR VALUES IN (' ||
+		        quote_literal(ev.catalogue) ||
+		        ') PARTITION BY LIST(entity)';
+	END IF;
+
+	-- Create entity partition exists if not yet exists
+    IF to_regclass(ent_part) IS NULL THEN
+    	-- CREATE TABLE ent_part PARTITION OF cat_part FOR VALUES IN (entity)
+		EXECUTE 'CREATE TABLE IF NOT EXISTS ' ||
+		        ent_part ||
+		        ' PARTITION OF ' || cat_part || ' FOR VALUES in (' ||
+		        quote_literal(ev.entity) ||
+		        ')';
+	END IF;
+
+	-- Insert event in the corresponding catalogue-entity partition
+	-- INSERT INTO ent_part (...) VALUES () 
+    EXECUTE 'INSERT INTO ' ||
+            ent_part || ' ' ||
+            '(' || 
+            'eventid, ' ||
+            '"timestamp", ' ||
+            'catalogue, ' ||
+            'entity, ' ||
+            '"version", ' ||
+            '"action", ' ||
+            '"source", ' ||
+            'source_id, ' ||
+            'contents, ' ||
+            'application' ||
+            ') ' ||
+            'VALUES (' ||
+            ev.eventid                    || ', ' ||
+            quote_literal(ev.timestamp)   || ', ' ||
+            quote_literal(ev.catalogue)   || ', ' ||
+            quote_literal(ev.entity)      || ', ' ||
+            quote_literal(ev.version)     || ', ' ||
+            quote_literal(ev.action)      || ', ' ||
+            quote_literal(ev.source)      || ', ' ||
+            quote_literal(ev.source_id)   || ', ' ||
+            quote_literal(ev.contents)    || ', ' ||
+            quote_literal(ev.application) ||
+            ')';
+END;
+$body$ LANGUAGE plpgsql;
+
+-- Call the Insert-into-events-partition function on every insert into the events table
+DROP RULE IF EXISTS autoCall_insertIntoEventsPartition ON events;
+CREATE RULE         autoCall_insertIntoEventsPartition
+AS
+	ON INSERT
+	TO events
+	DO INSTEAD (
+	    SELECT insertIntoEventsPartition(NEW);
+	);
+   
+-- Insert all events in the new partitioned events table
+INSERT INTO events SELECT * FROM events_org;
+
+-- Create indexes
+
+-- Improve find distinct source - catalogue - entity combinations
+DROP INDEX IF EXISTS events_source;
+CREATE INDEX         events_source  ON events ("source");
+
+-- Quickly find last eventid
+DROP INDEX IF EXISTS events_eventid;
+CREATE INDEX         events_eventid ON events (eventid);
+
+-- Quickly find last action for a specific entity
+DROP INDEX IF EXISTS events_action;
+CREATE INDEX         events_action  ON events ("action");
+
+-- The original events table van now be deleted
+-- However, just for sure, leave this statement for a next migration
+-- DROP TABLE events_org CASCADE;
+""")
+    # ### commands auto generated by Alembic - please adjust! ###
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    pass
+    # ### commands auto generated by Alembic - please adjust! ###
+    # ### end Alembic commands ###

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -432,7 +432,7 @@ WHERE
         return self.session.query(self.DbEvent).yield_per(10000) \
             .filter_by(source=self.metadata.source, catalogue=self.metadata.catalogue, entity=self.metadata.entity) \
             .filter(self.DbEvent.eventid > eventid if eventid else True) \
-            .order_by(self.DbEvent.eventid.asc())  # Parse events from youngest to oldest
+            .order_by(self.DbEvent.eventid.asc())  # Parse events from oldest to youngest
 
     @with_session
     def has_any_event(self, filter):

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -419,7 +419,7 @@ WHERE
         """
         result = self.session.query(self.DbEvent) \
             .filter_by(source=self.metadata.source, catalogue=self.metadata.catalogue, entity=self.metadata.entity) \
-            .order_by(self.DbEvent.eventid.desc(), self.DbEvent.timestamp.desc())\
+            .order_by(self.DbEvent.eventid.desc())\
             .first()
         return None if result is None else result.eventid
 
@@ -432,7 +432,7 @@ WHERE
         return self.session.query(self.DbEvent).yield_per(10000) \
             .filter_by(source=self.metadata.source, catalogue=self.metadata.catalogue, entity=self.metadata.entity) \
             .filter(self.DbEvent.eventid > eventid if eventid else True) \
-            .order_by(self.DbEvent.eventid)
+            .order_by(self.DbEvent.eventid.asc())  # Parse events from youngest to oldest
 
     @with_session
     def has_any_event(self, filter):

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -164,7 +164,7 @@ FROM   events
 WHERE  catalogue = '{catalog_name}' AND
        entity = '{collection_name}' AND
        action != 'CONFIRM'
-ORDER BY timestamp DESC
+ORDER BY eventid DESC
 LIMIT 1
 """
     last_change = _execute(query).scalar()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.13.24#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.13.25#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,7 +8,7 @@ coverage==4.5.1
 flake8==3.5.0
 GeoAlchemy2==0.5.0
 geomet==0.2.0.post2
--e git+https://github.com/Amsterdam/GOB-Core.git@v0.13.25#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v0.13.26#egg=gobcore
 idna==2.7
 Mako==1.0.7
 MarkupSafe==1.1.0

--- a/src/tests/storage/test_relate.py
+++ b/src/tests/storage/test_relate.py
@@ -28,7 +28,7 @@ FROM   events
 WHERE  catalogue = 'catalog' AND
        entity = 'collection' AND
        action != 'CONFIRM'
-ORDER BY timestamp DESC
+ORDER BY eventid DESC
 LIMIT 1
 """)
 


### PR DESCRIPTION
The migration of the current events table to the new partitioned events table will take approx 2 hours for 115.000.000 events.

The current events table is not deleted after migration. It will be deleted on a next migration.