### PR TITLE
Fix dict does not support indexing

### DIFF
--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -14,7 +14,7 @@ import functools
 import json
 import warnings
 
-from sqlalchemy import create_engine, Table, update, exc as sa_exc
+from sqlalchemy import create_engine, Table, update, exc as sa_exc, text as sa_text
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.exc import OperationalError
@@ -769,7 +769,7 @@ VALUES {values}"""
             self.added_session_entity_cnt = 0
 
     def execute(self, statement):
-        result = self.engine.execute(statement)
+        result = self.engine.execute(sa_text(statement))
         result.close()
 
     def get_query_value(self, query):

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -32,6 +32,7 @@ class MockedEngine:
         pass
 
 
+@patch("gobupload.storage.handler.sa_text", lambda x: x)
 class TestStorageHandler(unittest.TestCase):
 
     @patch('gobupload.storage.handler.create_engine', MagicMock())


### PR DESCRIPTION
Escape the input of the execute statement with the sqlalchemy.text function