### PR TITLE
Fix bug in autoid

### DIFF
--- a/src/gobupload/compare/enrich.py
+++ b/src/gobupload/compare/enrich.py
@@ -194,6 +194,9 @@ def _autoid(storage, data, specs, column, assigned):
 
     current = _get_current_value(storage, data, specs, column, assigned)
     if current:
+        # Insert current value and adjust last assigned value if required
+        data[column] = current
+        _update_last_assigned(data, specs, column, assigned)
         return current, None
 
     # No value is already stored neither has a value already been issued

--- a/src/gobupload/relate/table/update_table.py
+++ b/src/gobupload/relate/table/update_table.py
@@ -745,7 +745,9 @@ INNER JOIN {self.relation_table} rel
             for row in result:
                 row = dict(row)
                 # Log conflicting relations
-                if row.get("row_number", 0) > 1:
+                # Temporary bug-fix, final fix will be made by Jasper
+                # But otherwise this code would cause the e2e tests to fail
+                if (row.get("row_number") or 0) > 1:
                     data = {
                         f"src{FIELD.ID}": row.get(f"src{FIELD.ID}")
                     }

--- a/src/tests/compare/test_enrich.py
+++ b/src/tests/compare/test_enrich.py
@@ -358,3 +358,28 @@ class TestEnrichAutoid(TestCase):
         }
         with self.assertRaises(AutoIdException):
             result, _ = _autoid(storage, data, specs, column, assigned)
+
+    @patch("gobupload.compare.enrich._get_current_value")
+    @patch("gobupload.compare.enrich._update_last_assigned")
+    def test_autoid_with_current_value(self, mock_update, mock_current_value):
+        storage = None
+        column = 'any column'
+        data = {
+            column: None
+        }
+        specs = {
+            'on': 'any column',
+            'template': '00XX'
+        }
+        assigned = {
+            column: {
+                'issued': {},
+                'last': None
+            }
+        }
+        current_value = "any current value"
+        mock_current_value.return_value = current_value
+        result, _ = _autoid(storage, data, specs, column, assigned)
+        self.assertEqual(result, current_value)
+        self.assertEqual(data[column], current_value)
+        mock_update.assert_called()


### PR DESCRIPTION
When a current value is found in the storage
Update last assigned value if the current value is bigger then the last assigned value