### PR TITLE
Release apply bound to source if a source is specified

### DIFF
--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -44,6 +44,8 @@ def compare(msg):
 
     # Initialize a storage handler for the collection
     storage = GOBStorageHandler(metadata)
+    model = f"{metadata.source} {metadata.catalogue} {metadata.entity}"
+    logger.info(f"Compare {model}")
 
     stats = CompareStatistics()
 
@@ -100,7 +102,7 @@ def compare(msg):
     # Build result message
     results = stats.results()
 
-    logger.info(f"Compare completed", {'data': results})
+    logger.info(f"Compare {model} completed", {'data': results})
 
     results.update({
         'warnings': logger.get_warnings(),

--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -66,7 +66,7 @@ def _process_events(storage, events, stats):
 
 
 def full_update(msg):
-    """Apply the events on the current dataset
+    """Store the events for the current dataset
 
     :param msg: the result of the application of the events
     :return: Result message
@@ -79,6 +79,8 @@ def full_update(msg):
     metadata = message.metadata
 
     storage = GOBStorageHandler(metadata)
+    model = f"{metadata.source} {metadata.catalogue} {metadata.entity}"
+    logger.info(f"Store events {model}")
 
     # Get events from message
     events = msg["contents"]
@@ -92,7 +94,7 @@ def full_update(msg):
     results = stats.results()
 
     stats.log()
-    logger.info(f"Update completed", {'data': results})
+    logger.info(f"Store events {model} completed", {'data': results})
 
     results.update({
         'warnings': logger.get_warnings(),


### PR DESCRIPTION
In order to process data from multiple sources in parallel
the application of events should also be bound to a source

This prevents that the one process applies already the events of another process