### PR TITLE
Release use a temp table name for comparison

### DIFF
--- a/src/gobupload/compare/entity_collector.py
+++ b/src/gobupload/compare/entity_collector.py
@@ -13,7 +13,7 @@ class EntityCollector:
         :param storage:
         """
         self.storage = storage
-        self.storage.create_temporary_table()
+        self.tmp_table_name = self.storage.create_temporary_table()
 
     def close(self):
         self.storage.close_temporary_table()

--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -49,6 +49,7 @@ def compare(msg):
 
     stats = CompareStatistics()
 
+    tmp_table_name = None
     with storage.get_session():
         with ProgressTicker("Collect compare events", 10000) as progress:
             # Check any dependencies
@@ -79,6 +80,7 @@ def compare(msg):
                 # Collect entities in a temporary table
                 collector = EntityCollector(storage)
                 collect = collector.collect
+                tmp_table_name = collector.tmp_table_name
 
             for entity in msg["contents"]:
                 progress.tick()
@@ -96,7 +98,7 @@ def compare(msg):
     else:
         # Compare entities from temporary table
         with storage.get_session():
-            diff = storage.compare_temporary_data(mode)
+            diff = storage.compare_temporary_data(tmp_table_name, mode)
             filename, confirms = _process_compare_results(storage, entity_model, diff, stats)
 
     # Build result message

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -275,7 +275,7 @@ WHERE
 
         # Make sure the test table already exists
         self.storage.base.metadata.tables = {expected_table: mock_table}
-        self.storage.create_temporary_table()
+        expected_table = self.storage.create_temporary_table()
 
         # Assert the drop function is called
         self.storage.engine.execute.assert_any_call(f"DROP TABLE IF EXISTS {expected_table}")
@@ -293,7 +293,7 @@ WHERE
         fields = ['_source', 'identificatie']
         query = queries.get_comparison_query('any source', current, temporary, fields)
 
-        diff = self.storage.compare_temporary_data()
+        diff = self.storage.compare_temporary_data(temporary)
         results = [result for result in diff]
 
         # Assert the query is performed is deleted


### PR DESCRIPTION
To prevent collissions when running multiple compares
for the same catalog-collection for different sources