### PR TITLE
Relate BAG verblijfsobjecten heeft hoofdadres fails

### DIFF
--- a/src/gobupload/relate/table/entrypoint.py
+++ b/src/gobupload/relate/table/entrypoint.py
@@ -44,6 +44,8 @@ def relate_table_src_message_handler(msg: dict):
     _check_message(msg)
     header = msg.get('header')
 
+    logger.info(f"Relate table started")
+
     updater = RelationTableRelater(header[CATALOG_KEY], header[COLLECTION_KEY], header[ATTRIBUTE_KEY])
     filename, confirms = updater.update()
 

--- a/src/gobupload/storage/execute.py
+++ b/src/gobupload/storage/execute.py
@@ -22,4 +22,4 @@ def _execute_multiple(queries, stream=False, max_row_buffer=1000):
 
 
 def _execute(query, stream=False, max_row_buffer=1000):
-    return _execute_multiple([query], stream)
+    return _execute_multiple([query], stream, max_row_buffer)

--- a/src/tests/storage/test_execute.py
+++ b/src/tests/storage/test_execute.py
@@ -36,7 +36,7 @@ class TestExecute(TestCase):
 
     @patch("gobupload.storage.execute._execute_multiple")
     def test_execute(self, mock_execute_multiple):
-        res = _execute('some query', 'TrueOrFalse')
+        res = _execute('some query', 'TrueOrFalse', 123)
 
-        mock_execute_multiple.assert_called_with(['some query'], 'TrueOrFalse')
+        mock_execute_multiple.assert_called_with(['some query'], 'TrueOrFalse', 123)
         self.assertEqual(mock_execute_multiple.return_value, res)


### PR DESCRIPTION
This PR is not a solution to the problem. I found however a few things to improve:

1. The max_row_buffer parameter was not used. The standard parameter is 1000 rows each which is rather limited for a 2M row table.
2. The logging was only showing the end, not the begin of the action. Makes it a little easier to detect the problem in the future.
3. Any failure resulted in a mystical dump without specifying the failing action. We do not have any tagging of ACC and PROD releases so it is unclear what the exact failing query is. The query is now printed on failure.

None of the fixes will probably fix the problem but as we don not have access to production data the logging should provide us with better clues to fix the problem.