### PR TITLE
PGB-975 Change 'missing referenced entity' warning to datawarning

### DIFF
--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -316,7 +316,7 @@ def _query_missing(query, check, attr, max_warnings=50):
 
     items_name = f"{attr} {check['msg']}"
     if count > max_warnings:
-        logger.warning(f"{items_name}: {count} actual errors, reported first {max_warnings} only")
+        logger.data_warning(f"{items_name}: {count} actual errors, reported first {max_warnings} only")
     if historic_count > 0:
         logger.info(f"{items_name}: {historic_count} historical errors")
 

--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -316,9 +316,9 @@ def _query_missing(query, check, attr, max_warnings=50):
 
     items_name = f"{attr} {check['msg']}"
     if count > max_warnings:
-        logger.data_warning(f"{items_name}: {count} actual errors, reported first {max_warnings} only")
+        logger.data_warning(f"{items_name}: {count} actual warnings, reported first {max_warnings} only")
     if historic_count > 0:
-        logger.info(f"{items_name}: {historic_count} historical errors")
+        logger.data_info(f"{items_name}: {historic_count} historical errors")
 
 
 def _get_relation_check_query(query_type, src_catalog_name, src_collection_name, src_field_name):


### PR DESCRIPTION
From ticket:

"Dit zijn allemaal data warnings. Tevens klopt het aantal 27 niet, als de 25 warnings geen datameldingen zijn zouden er 26 warnings moeten staan (25 + die regel) en 51 datawarnings."

This PR handles the case for the 51 datawarnings. One of those 27 warnings is changed to a datwarning. Now the total warnings is indeed 26 and this job now returns 51 datawarnings (was 50).
