### PR TITLE
Fix for missing src_volgnummer

### DIFF
--- a/src/gobupload/storage/relate.py
+++ b/src/gobupload/storage/relate.py
@@ -493,7 +493,7 @@ def check_relation_conflicts(catalog_name, collection_name, attribute_name):
         if (row.get("row_number") or 0) > 1:
 
             if conflicts < _MAX_RELATION_CONFLICTS:
-                row['volgnummer'] = row['src_volgnummer']
+                row['volgnummer'] = row.get('src_volgnummer')
                 issue = Issue(QA_CHECK.Unique_destination, row, 'src_id', 'bronwaarde')
                 issue.attribute = attribute_name
                 log_issue(logger, QA_LEVEL.WARNING, issue)


### PR DESCRIPTION
If a collection has no states then the volgnummer is None
The 'src_volgnummer' attribute does not exist in the conflicting row