### PR TITLE
Improve performance of apply events

### DIFF
--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -54,7 +54,8 @@ class EventApplicator:
 
     def add_other_event(self, gob_event, data):
         """
-        Add a non-ADD event. If MAX_OTHER_CHUNK events have been buffered then mass-apply the events
+        Add a non-ADD event, or an ADD event on a deleted entity
+        If MAX_OTHER_CHUNK events have been buffered then mass-apply the events
 
         :param gob_event:
         :param data:
@@ -83,7 +84,7 @@ class EventApplicator:
         """
         Apply an event on an entity
 
-        The event van be an:
+        The event can be an:
         - ADD event (reanimation of a DELETED entity)
         - DELETE or MODIFY event
         - CONFIRM event (these event only set the last modified date, not the last event id)

--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -6,6 +6,7 @@ Applies events to the respective entity in the current model
 """
 import json
 
+from gobcore.exceptions import GOBException
 from gobcore.events import GOB, GobEvent
 from gobcore.events.import_message import MessageMetaData
 
@@ -18,19 +19,27 @@ from gobupload.utils import ActiveGarbageCollection
 class EventApplicator:
 
     MAX_ADD_CHUNK = 10000
+    MAX_OTHER_CHUNK = 10000
 
     def __init__(self, storage, last_events):
         self.storage = storage
         # Use a lookup table to tell if an entity is new to the collection
         self.last_events = last_events
+        # Buffer (initial) ADD events and other events
         self.add_events = []
+        self.other_events = {}
 
     def __enter__(self):
+        # Initialize buffers
         self.add_events = []
+        self.other_events = {}
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        # Write any buffered entities and flush storage
         self.apply_add_events()
+        self.apply_other_events()
+        self.storage.force_flush_entities()
 
     def add_add_event(self, event):
         self.add_events.append(event)
@@ -42,6 +51,61 @@ class EventApplicator:
             with ActiveGarbageCollection("Apply add events"):
                 self.storage.add_add_events(self.add_events)
                 self.add_events = []
+
+    def add_other_event(self, gob_event, data):
+        """
+        Add a non-ADD event. If MAX_OTHER_CHUNK events have been buffered then mass-apply the events
+
+        :param gob_event:
+        :param data:
+        :return:
+        """
+        self.other_events[data["_entity_source_id"]] = gob_event
+        if len(self.other_events) >= self.MAX_OTHER_CHUNK:
+            self.apply_other_events()
+
+    def apply_other_events(self):
+        """
+        Mass-Apply events
+
+        :return:
+        """
+        if self.other_events:
+            with ActiveGarbageCollection("Apply other events"):
+                # Get all entities to be updated by their source-id
+                source_ids = self.other_events.keys()
+                entities = self.storage.get_entities(source_ids, with_deleted=True)
+                for entity in entities:
+                    self.apply_other_event(entity)
+            self.other_events = {}
+
+    def apply_other_event(self, entity):
+        """
+        Apply an event on an entity
+
+        The event van be an:
+        - ADD event (reanimation of a DELETED entity)
+        - DELETE or MODIFY event
+        - CONFIRM event (these event only set the last modified date, not the last event id)
+
+        :param entity:
+        :return:
+        """
+        gob_event = self.other_events[entity._source_id]
+
+        # Check action validity
+        if entity._date_deleted is not None and not isinstance(gob_event, GOB.ADD):
+            # a non-ADD event is trying to be applied on a deleted entity
+            # Only ADD event can be applied on a deleted entity
+            raise GOBException(f"Trying to '{gob_event.name}' a deleted entity")
+
+        # apply the event on the entity
+        gob_event.apply_to(entity)
+
+        # and register the last event that has updated this entity
+        # except for CONFIRM events. These events are deleted once they have been applied
+        if not isinstance(gob_event, GOB.CONFIRM):
+            entity._last_event = gob_event.id
 
     def apply(self, event):
         # Parse the json data of the event
@@ -62,22 +126,14 @@ class EventApplicator:
             action = "CONFIRM"
             count = len(gob_event._data['confirms'])
         elif isinstance(gob_event, GOB.ADD) and self.last_events.get(data["_entity_source_id"]) is None:
-            # Initial add
+            # Initial add (an ADD event can also be applied on a deleted entity, this is handled by the else case)
             self.add_add_event(gob_event)
         else:
             # If ADD events are waiting to be applied to the database, flush those first to make sure they exist
             self.apply_add_events()
 
-            # Get the entity to which the event should be applied, create if ADD event
-            entity = self.storage.get_entity_for_update(event, data)
-
-            # apply the event on the entity
-            gob_event.apply_to(entity)
-
-            # and register the last event that has updated this entity
-            # except for CONFIRM events. These events are deleted once they have been applied
-            if not isinstance(gob_event, GOB.CONFIRM):
-                entity._last_event = event.eventid
+            # Add other event (MODIFY, CONFIRM, DELETE, ADD on deleted entity)
+            self.add_other_event(gob_event, data)
 
         return action, count
 


### PR DESCRIPTION
Group events and apply the events in bulk

Instead of retrieving each entity, apply the event and flush per 1000 updates
Events are buffered, retrieved in bulk and applied and flushed per 10000

Performance improvement: 2 to 3 times faster than before