### PR TITLE
Fix the bug with auto id

### DIFF
--- a/src/gobupload/compare/enrich.py
+++ b/src/gobupload/compare/enrich.py
@@ -26,9 +26,13 @@ class Enricher:
         self.assigned = {}
         for column, specs in self.enrich_spec.items():
             self.assigned[column] = {
-                "last": None,
                 "issued": {}
             }
+
+            # For autoid, always prefill the last value with the last value in the storage
+            if specs["type"] == "autoid":
+                find_template = re.sub(r'X*$', '%', specs["template"])
+                self.assigned[column]["last"] = storage.get_last_column_value(find_template, column)
 
         self.enrichers = {
             "geounion": {"func": _geounion, "description": "Generate geometry from other geometries"},

--- a/src/gobupload/compare/enrich.py
+++ b/src/gobupload/compare/enrich.py
@@ -207,10 +207,6 @@ def _autoid(storage, data, specs, column, assigned):
     # Get last issued value
     last_value = assigned[column]["last"]
     template = specs["template"]
-    if not last_value:
-        # If no last issued value exist, check the storage for any last value with the same template
-        find_template = re.sub(r'X*$', '%', template)
-        last_value = storage.get_last_column_value(find_template, column)
 
     if last_value:
         # Create an id that follows the last value


### PR DESCRIPTION
On partial imports, some records could already have been assigned a value on a previous run. This value was being used to determine the next value, but it would not necessarily be the highest value in the database. To prevent this, we will set the last value when the enricher is initialized