### PR TITLE
Fix event ID's passed to EventNotification

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from gobcore.logging.logger import logger
 from gobcore.utils import ProgressTicker
@@ -111,7 +112,7 @@ def apply(msg):
 
         # Track eventId before event application
         entity_max_eventid, last_eventid = get_event_ids(storage)
-        before = min(last_eventid, before or last_eventid)
+        before = min(entity_max_eventid or 0, before or sys.maxsize)
 
         if is_corrupted(entity_max_eventid, last_eventid):
             logger.error(f"Model {model} is inconsistent! data is more recent than events")
@@ -128,7 +129,7 @@ def apply(msg):
 
         # Track eventId after event application
         entity_max_eventid, last_eventid = get_event_ids(storage)
-        after = max(last_eventid, after or last_eventid)
+        after = max(entity_max_eventid or 0, after or 0)
 
         # Build result message
         results = stats.results()


### PR DESCRIPTION
The DUMP wasn't triggered, because 'before' and 'after' were always equal. Both 'before' and 'after' were set based on the max event in the events table, but in apply these don't change. For DUMP, we are interested in the state of the object table. The max event id in the object table before and after applying events.

Example:
Say STORE events has stored events 0 to 100. The max event in the object table is 50. Before this PR, before = 100 and after = 100 would be returned, as the max event in the events table doesn't change in APPLY. Now before = 50 and after = 100 is returned.