### PR TITLE
Relate check configure logger with its own id

### DIFF
--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -45,7 +45,7 @@ def check_relation(msg):
 
     model = GOBModel()
 
-    logger.configure(msg, "RELATE")
+    logger.configure(msg, "RELATE_CHECK")
     logger.info(f"Relate check started")
 
     collection = model.get_collection(catalog_name, collection_name)


### PR DESCRIPTION
This is required to get the issues reported on the correct process id