### PR TITLE
PGB-1602 Improve relate

### DIFF
--- a/src/gobupload/relate/update.py
+++ b/src/gobupload/relate/update.py
@@ -661,11 +661,12 @@ WHERE catalogue = '{catalogue}'
 
         if not self.exclude_relation_table and not initial_load:
             last_eventid = f"(SELECT COALESCE(MAX({FIELD.LAST_SRC_EVENT}), 0) FROM {self.relation_table})"
+            source_attrs = [spec['source_attribute'] for spec in self.relation_specs if 'source_attribute' in spec]
             changed_source_ids = self._changed_source_ids(
                 self.src_catalog_name,
                 self.src_collection_name,
                 last_eventid,
-                [self.src_field_name]
+                [self.src_field_name] + source_attrs
             )
 
             filters.append(f"src.{FIELD.SOURCE_ID} IN ({changed_source_ids})")

--- a/src/tests/relate/test_update.py
+++ b/src/tests/relate/test_update.py
@@ -40,6 +40,7 @@ class MockSources:
         }]
 
 
+@patch("gobupload.relate.update.logger", MagicMock())
 @patch("gobupload.relate.update.Relater.model", MockModel())
 @patch("gobupload.relate.update.Relater.sources", MockSources())
 @patch("gobupload.relate.update._execute")
@@ -85,6 +86,8 @@ class TestRelaterInit(TestCase):
             e = self._get_relater()
             self.assertEqual(True, e.is_many)
 
+
+@patch("gobupload.relate.update.logger", MagicMock())
 @patch("gobupload.relate.update.Relater.model", MockModel())
 @patch("gobupload.relate.update.Relater.sources", MockSources())
 @patch("gobupload.relate.update.Relater._get_applications_in_src", lambda *args: ['applicationA', 'applicationB'])

--- a/src/tests/relate/test_update.py
+++ b/src/tests/relate/test_update.py
@@ -811,6 +811,7 @@ WHERE catalogue = 'CATALOG'
         relater = self._get_relater()
         relater._source_value_ref = lambda: 'SOURCE_VAL_REF'
         relater._changed_source_ids = MagicMock(return_value='CHANGED_SRC_IDS')
+        relater.relation_specs = [{'source_attribute': 'attrA'}, {'source_attribute': 'attrB'}, {}]
         relater.is_many = True
         expected = f"""
 SELECT * FROM src_catalog_name_src_collection_name_table src
@@ -822,7 +823,7 @@ WHERE src._source_id IN (CHANGED_SRC_IDS)
             'src_catalog_name',
             'src_collection_name',
             "(SELECT COALESCE(MAX(_last_src_event), 0) FROM rel_src_catalog_name_src_collection_name_src_field_name)",
-            ['src_field_name']
+            ['src_field_name', 'attrA', 'attrB']
         )
         expected = f"""
 SELECT * FROM src_catalog_name_src_collection_name_table src


### PR DESCRIPTION
- Inspect MODIFY events to better determine which objects to include in the update.
- Trigger initial relate when a large part of src and dst objects need to be re-inspected