### PR TITLE
Add 'suppress_notifications' flag to apply events to avoid update_mod…

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -146,6 +146,7 @@ def apply(msg):
     }
 
     # Add a events notification telling what types of event have been applied
-    add_notification(msg, EventNotification(stats.applied, [before, after]))
+    if not msg['header'].get('suppress_notifications', False):
+        add_notification(msg, EventNotification(stats.applied, [before, after]))
 
     return msg


### PR DESCRIPTION
…el triggering a dump.

Flag is set and unset in the import workflow.

Reason is that the first update_model triggered a dump and consistency tests, but that often preceeds an update. This means that the dump/consistency tests that are triggerd by the first update_model step are actually dumping and testing old data, before we're importing the new data.

This could cause weird data consistency errors. Also made the e2e tests fail when the timings were solved.