### PR TITLE
PGB-1657: Relate objects with begin_geldigheid = eind_geldigheid.

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -18,6 +18,7 @@ from gobupload import relate
 from gobupload import update
 from gobupload import apply
 from gobupload.storage.handler import GOBStorageHandler
+from gobupload.config import DEBUG
 
 SERVICEDEFINITION = {
     'apply': {
@@ -92,6 +93,9 @@ parser.add_argument('--materialized_views',
                     default=False,
                     help='force recreation of materialized views')
 args = parser.parse_args()
+
+if DEBUG:
+    print("WARNING: Debug mode is ON")
 
 # Initialize database tables
 storage = GOBStorageHandler()

--- a/src/gobupload/config.py
+++ b/src/gobupload/config.py
@@ -2,6 +2,8 @@ import os
 
 FULL_UPLOAD = "full"
 
+DEBUG = True if os.getenv("DEBUG") else False
+
 GOB_DB = {
     'drivername': 'postgres',
     'username': os.getenv("DATABASE_USER", "gob"),

--- a/src/gobupload/dev_utils/relate_interval_table.py
+++ b/src/gobupload/dev_utils/relate_interval_table.py
@@ -1,0 +1,26 @@
+import sys
+
+from gobupload.relate.update import StartValiditiesTable
+
+
+def run():
+    assert len(sys.argv) == 4, "Missing arguments: relate_interval_table.py " \
+                               "gebieden wijken table_name"
+
+    catalog = sys.argv[1]
+    collection = sys.argv[2]
+    table_name = sys.argv[3]
+
+    table = StartValiditiesTable.from_catalog_collection(catalog, collection, table_name)
+    table.create()
+    print(f"Table {table.name} created")
+
+
+if __name__ == "__main__":
+    """
+    python -m gobupload.dev_utils.relate_interval_table gebieden wijken [table_name]
+
+    Builds the interval table as used by relate: the table with id, volgnummer, begin_geldigheid for each object
+
+    """
+    run()

--- a/src/gobupload/dev_utils/relate_query.py
+++ b/src/gobupload/dev_utils/relate_query.py
@@ -10,12 +10,25 @@ def run():
     catalog = sys.argv[1]
     collection = sys.argv[2]
     attribute = sys.argv[3]
-    initial = False if len(sys.argv) == 4 else sys.argv[4].lower() == 'initial'
-    check_conflicts = False if len(sys.argv) == 4 else sys.argv[4].lower() == 'conflicts'
+    option = sys.argv[4] if len(sys.argv) >= 5 else None
+    initial = option == 'initial'
+    check_conflicts = option == 'conflicts'
 
     relater = Relater(catalog, collection, attribute)
 
     print(relater.get_conflicts_query() if check_conflicts else relater.get_query(initial))
+
+    if relater.src_has_states or relater.dst_has_states:
+        print("")
+        print("NOTE: Temporary tables are not created. Create the temporary tables with the following commands.")
+
+        if relater.src_has_states:
+            print(f"python -m gobupload.dev_utils.relate_interval_table {catalog} {collection} "
+                  f"{relater.src_intv_tmp_table.name}")
+
+        if relater.dst_has_states and relater.src_intv_tmp_table.name != relater.dst_intv_tmp_table.name:
+            print(f"python -m gobupload.dev_utils.relate_interval_table {relater.dst_catalog_name} "
+                  f"{relater.dst_collection_name} {relater.dst_intv_tmp_table.name}")
 
 
 if __name__ == "__main__":

--- a/src/tests/dev_utils/test_relate_interval_table.py
+++ b/src/tests/dev_utils/test_relate_interval_table.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from gobupload.dev_utils.relate_interval_table import run
+
+
+class TestRelateIntervalTable(TestCase):
+
+    @patch("gobupload.dev_utils.relate_interval_table.StartValiditiesTable")
+    @patch("gobupload.dev_utils.relate_interval_table.sys")
+    def test_run(self, mock_sys, mock_table):
+
+        mock_sys.argv = []
+
+        with self.assertRaises(AssertionError):
+            run()
+
+        mock_sys.argv = ['relate_interval_table.py', 'catalog', 'collection', 'table_name']
+        run()
+        mock_table.from_catalog_collection.assert_called_with('catalog', 'collection', 'table_name')
+        mock_table.from_catalog_collection().create.assert_called_once()

--- a/src/tests/dev_utils/test_relate_query.py
+++ b/src/tests/dev_utils/test_relate_query.py
@@ -19,16 +19,16 @@ class TestRelateQuery(TestCase):
         run()
         mock_relater.assert_called_with('catalog', 'collection', 'attribute')
         mock_relater.return_value.get_query.assert_called_with(False)
-        mock_print.assert_called_with(mock_relater.return_value.get_query.return_value)
+        mock_print.assert_any_call(mock_relater.return_value.get_query.return_value)
 
         mock_sys.argv = ['relate_query.py', 'catalog', 'collection', 'attribute', 'initial']
         run()
         mock_relater.assert_called_with('catalog', 'collection', 'attribute')
         mock_relater.return_value.get_query.assert_called_with(True)
-        mock_print.assert_called_with(mock_relater.return_value.get_query.return_value)
+        mock_print.assert_any_call(mock_relater.return_value.get_query.return_value)
 
         mock_sys.argv = ['relate_query.py', 'catalog', 'collection', 'attribute', 'conflicts']
         run()
         mock_relater.assert_called_with('catalog', 'collection', 'attribute')
         mock_relater.return_value.get_conflicts_query.assert_called()
-        mock_print.assert_called_with(mock_relater.return_value.get_conflicts_query.return_value)
+        mock_print.assert_any_call(mock_relater.return_value.get_conflicts_query.return_value)


### PR DESCRIPTION
- Add OR clause in the relate to relate those objects.
- Extract Validities tmp table into its own class.
- Use extracted class in new command line tool to generate tmp tables in development environment.