### PR TITLE
PGB-1897 Decrease likelihood of collisions in relate tmp table names.…

### DIFF
--- a/src/gobupload/relate/update.py
+++ b/src/gobupload/relate/update.py
@@ -5,6 +5,7 @@ See README.md in this directory for explanation of this file.
 import hashlib
 import json
 import random
+import string
 
 from datetime import date, datetime
 from typing import List
@@ -242,10 +243,11 @@ class Relater:
 
         # begin_geldigheid tmp table names
         datestr = datetime.now().strftime('%Y%m%d')
-        src_intv_tmp_table_name = f"tmp_{self.src_catalog_name}_{self.src_collection['abbreviation']}_intv_" \
-                                  f"{datestr}_{str(random.randint(0, 1000)).zfill(4)}".lower()
-        dst_intv_tmp_table_name = f"tmp_{self.dst_catalog_name}_{self.dst_collection['abbreviation']}_intv_" \
-                                  f"{datestr}_{str(random.randint(0, 1000)).zfill(4)}".lower()
+        characters = string.ascii_lowercase + ''.join([str(i) for i in range(10)])
+        src_intv_tmp_table_name = f"tmp_{self.src_catalog_name}_{self.src_collection['abbreviation']}_intv_{datestr}" \
+                                  f"_{''.join([random.choice(characters) for _ in range(6)])}".lower()
+        dst_intv_tmp_table_name = f"tmp_{self.dst_catalog_name}_{self.dst_collection['abbreviation']}_intv_{datestr}" \
+                                  f"_{''.join([random.choice(characters) for _ in range(6)])}".lower()
 
         self.src_intv_tmp_table = StartValiditiesTable(self.src_table_name, src_intv_tmp_table_name)
         self.dst_intv_tmp_table = StartValiditiesTable(self.dst_table_name, dst_intv_tmp_table_name)

--- a/src/gobupload/relate/update.py
+++ b/src/gobupload/relate/update.py
@@ -4,8 +4,6 @@ See README.md in this directory for explanation of this file.
 
 import hashlib
 import json
-import random
-import string
 
 from datetime import date, datetime
 from typing import List
@@ -26,6 +24,7 @@ from gobupload.relate.exceptions import RelateException
 from gobupload.storage.execute import _execute
 from gobupload.compare.event_collector import EventCollector
 from gobupload.config import DEBUG
+from gobupload.utils import random_string
 
 EQUALS = 'equals'
 LIES_IN = 'lies_in'
@@ -243,11 +242,10 @@ class Relater:
 
         # begin_geldigheid tmp table names
         datestr = datetime.now().strftime('%Y%m%d')
-        characters = string.ascii_lowercase + ''.join([str(i) for i in range(10)])
         src_intv_tmp_table_name = f"tmp_{self.src_catalog_name}_{self.src_collection['abbreviation']}_intv_{datestr}" \
-                                  f"_{''.join([random.choice(characters) for _ in range(6)])}".lower()
+                                  f"_{random_string(6)}".lower()
         dst_intv_tmp_table_name = f"tmp_{self.dst_catalog_name}_{self.dst_collection['abbreviation']}_intv_{datestr}" \
-                                  f"_{''.join([random.choice(characters) for _ in range(6)])}".lower()
+                                  f"_{random_string(6)}".lower()
 
         self.src_intv_tmp_table = StartValiditiesTable(self.src_table_name, src_intv_tmp_table_name)
         self.dst_intv_tmp_table = StartValiditiesTable(self.dst_table_name, dst_intv_tmp_table_name)

--- a/src/gobupload/utils.py
+++ b/src/gobupload/utils.py
@@ -1,4 +1,6 @@
 import gc
+import string
+import random
 
 
 class ActiveGarbageCollection:
@@ -45,3 +47,14 @@ def get_event_ids(storage):
         entity_max_eventid = storage.get_entity_max_eventid()
         last_eventid = storage.get_last_eventid()
         return entity_max_eventid, last_eventid
+
+
+def random_string(length):
+    """Returns a random string of length :length: consisting of lowercase characters and digits
+
+    :param length:
+    :return:
+    """
+    assert length > 0
+    characters = string.ascii_lowercase + ''.join([str(i) for i in range(10)])
+    return ''.join([random.choice(characters) for _ in range(length)])

--- a/src/tests/relate/test_update.py
+++ b/src/tests/relate/test_update.py
@@ -125,7 +125,7 @@ GROUP BY _id, volgnummer
 @patch("gobupload.relate.update.Relater.model", MockModel())
 @patch("gobupload.relate.update.Relater.sources", MockSources())
 @patch("gobupload.relate.update._execute")
-@patch("gobupload.relate.update.random.choice", lambda x: 'a')
+@patch("gobupload.relate.update.random_string", lambda x: x * 'a')
 @patch("gobupload.relate.update.get_relation_name", lambda m, cat, col, field: f"{cat}_{col}_{field}")
 class TestRelaterInit(TestCase):
 

--- a/src/tests/relate/test_update.py
+++ b/src/tests/relate/test_update.py
@@ -125,7 +125,7 @@ GROUP BY _id, volgnummer
 @patch("gobupload.relate.update.Relater.model", MockModel())
 @patch("gobupload.relate.update.Relater.sources", MockSources())
 @patch("gobupload.relate.update._execute")
-@patch("gobupload.relate.update.random.randint", lambda x, y: 89)
+@patch("gobupload.relate.update.random.choice", lambda x: 'a')
 @patch("gobupload.relate.update.get_relation_name", lambda m, cat, col, field: f"{cat}_{col}_{field}")
 class TestRelaterInit(TestCase):
 
@@ -156,8 +156,8 @@ class TestRelaterInit(TestCase):
         self.assertEqual('rel_src_catalog_name_src_collection_name_src_field_name', e.relation_table)
         mock_execute.assert_called_with("SELECT DISTINCT _application FROM src_catalog_name_src_collection_name_table")
 
-        self.assertEqual('tmp_src_catalog_name_srcabbr_intv_20200101_0089', e.src_intv_tmp_table.name)
-        self.assertEqual('tmp_dst_catalog_name_dstabbr_intv_20200101_0089', e.dst_intv_tmp_table.name)
+        self.assertEqual('tmp_src_catalog_name_srcabbr_intv_20200101_aaaaaa', e.src_intv_tmp_table.name)
+        self.assertEqual('tmp_dst_catalog_name_dstabbr_intv_20200101_aaaaaa', e.dst_intv_tmp_table.name)
 
         with patch('gobupload.relate.update.Relater.sources.get_field_relations',
                    lambda cat, col, field: []):

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-from gobupload.utils import ActiveGarbageCollection
+from string import ascii_lowercase
+
+from gobupload.utils import ActiveGarbageCollection, random_string
 
 
 class TestUpdate(TestCase):
@@ -18,3 +20,18 @@ class TestUpdate(TestCase):
             self.assertEqual(agc.title, "any title")
             self.assertEqual(mocked_gc.collect.call_count, 1)
         self.assertEqual(mocked_gc.collect.call_count, 2)
+
+    def test_random_string(self):
+        self.assertEqual(6, len(random_string(6)))
+        self.assertEqual(8, len(random_string(8)))
+
+        expected_characters = ascii_lowercase + '0123456789'
+
+        self.assertTrue(all([c in expected_characters for c in random_string(200)]))
+        self.assertTrue(all([c in expected_characters for c in random_string(10)]))
+
+        try:
+            self.assertNotEqual(random_string(1000), random_string(1000))
+        except AssertionError:
+            # Just in the very very very small case the first two strings are equal
+            self.assertNotEqual(random_string(1000), random_string(1000))


### PR DESCRIPTION
… Use 6 random characters and numbers instead of 4 random numbers