### PR TITLE
Handle empty result in `_geounion` enricher

### DIFF
--- a/src/gobupload/compare/enrich.py
+++ b/src/gobupload/compare/enrich.py
@@ -122,12 +122,15 @@ SELECT
       )
 FROM  {table_name}
 WHERE {field} in ({', '.join(values)})
-AND   {FIELD.END_VALIDITY} IS NULL
+AND   ({FIELD.END_VALIDITY} IS NULL OR {FIELD.END_VALIDITY} > NOW())
 """
 
     result = storage.get_query_value(query)
-    result = Geometry.from_value(result)
-    return str(result), None
+
+    if result is not None:
+        result = str(Geometry.from_value(result))
+
+    return result, None
 
 
 class AutoIdException(Exception):

--- a/src/gobupload/compare/enrich.py
+++ b/src/gobupload/compare/enrich.py
@@ -115,6 +115,8 @@ def _geounion(storage, data, specs, column, assigned):
     # Derive the fieldname that contains the geometry in the other table
     geometrie = specs["geometrie"]
 
+    # Consider as valid end_validity: NULL or date in the future
+    # Otherwise currently valid values are not returned, only the actual ones
     query = f"""
 SELECT
       ST_AsText(
@@ -127,10 +129,7 @@ AND   ({FIELD.END_VALIDITY} IS NULL OR {FIELD.END_VALIDITY} > NOW())
 
     result = storage.get_query_value(query)
 
-    if result is not None:
-        result = str(Geometry.from_value(result))
-
-    return result, None
+    return Geometry.from_value(result).to_value, None
 
 
 class AutoIdException(Exception):

--- a/src/tests/compare/test_enrich.py
+++ b/src/tests/compare/test_enrich.py
@@ -55,7 +55,7 @@ SELECT
       )
 FROM  cat_col
 WHERE fld in ('1', '2')
-AND   eind_geldigheid IS NULL
+AND   (eind_geldigheid IS NULL OR eind_geldigheid > NOW())
 """)
         self.assertEqual(msg["contents"][0]["geo"], "POINT (1.000 2.000)")
 
@@ -77,11 +77,11 @@ SELECT
       )
 FROM  cat_col
 WHERE fld in ('1', '2')
-AND   eind_geldigheid IS NULL
+AND   (eind_geldigheid IS NULL OR eind_geldigheid > NOW())
 """)
         self.assertEqual(msg["contents"][0]["geo"], "POINT (1.000 2.000)")
 
-    def test_enrich_mulit_complex_contents(self):
+    def test_enrich_multi_complex_contents(self):
         self.mock_storage.get_query_value.return_value = "POINT (1 2)"
         msg = self.mock_msg
         msg["header"]["enrich"]["geo"]["on"] = "x.y.z"
@@ -99,7 +99,7 @@ SELECT
       )
 FROM  cat_col
 WHERE fld in ('1', '2')
-AND   eind_geldigheid IS NULL
+AND   (eind_geldigheid IS NULL OR eind_geldigheid > NOW())
 """)
         self.assertEqual(msg["contents"][0]["geo"], "POINT (1.000 2.000)")
 
@@ -114,6 +114,17 @@ AND   eind_geldigheid IS NULL
 
         self.mock_storage.get_query_value.assert_not_called()
         self.assertEqual(msg["contents"][0]["geo"], "aap")
+
+    def test_enrich_geounion_none(self):
+        self.mock_storage.get_query_value.return_value = None
+        msg = self.mock_msg
+        msg["contents"] = [{"x": [1, 2]}]
+        enricher = Enricher(self.mock_storage, msg)
+
+        for content in msg["contents"]:
+            enricher.enrich(content)
+
+        self.assertIsNone(msg["contents"][0]['geo'])
 
 
 @patch('gobupload.compare.enrich.logger', MagicMock())


### PR DESCRIPTION
The `_geounion` needs to return None instead of a GeoType object. Otherwise the value can't be inserted in the db.