### PR TITLE
Update core with rel catalog fix

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 alembic==1.7.5
--e git+https://github.com/Amsterdam/GOB-Core.git@v1.0.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v1.3.2#egg=gobcore


### PR DESCRIPTION
Don't think the bug would have caused problems in this repo, as this repo doesn't use the legacy feature for GOBModel. Just in case.