### PR TITLE
Don't try to drop `pg_stat_statements` view

### DIFF
--- a/src/alembic/versions/0ce50938f539_gebieden_begin_eind_geldigheid_datetime.py
+++ b/src/alembic/versions/0ce50938f539_gebieden_begin_eind_geldigheid_datetime.py
@@ -32,7 +32,7 @@ def upgrade():
         c_views CURSOR FOR
         SELECT * FROM pg_views 
         WHERE schemaname='public' and viewowner != 'postgres' and viewname NOT IN (
-            'geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews'
+            'geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews', 'pg_stat_statements'
         );
     BEGIN
         FOR v in c_views LOOP


### PR DESCRIPTION
You can't drop this view if it's used by the extension