### PR TITLE
Warn when relations are skipped in preparing relate

### DIFF
--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -107,8 +107,9 @@ def _split_job(msg: dict):
                 relation_specs = sources.get_field_relations(catalog_name, collection_name, attr_name)
 
                 if not relation_specs:
-                    logger.info(f"Missing relation specification for {catalog_name} {collection_name} "
-                                f"{attr_name}. Skipping")
+                    logger.warning(
+                        f"Missing relation specification for {catalog_name} {collection_name} {attr_name}. Skipping"
+                    )
                     continue
 
                 if relation_specs[0]['type'] == fully_qualified_type_name(VeryManyReference):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 alembic==1.8.1
--e git+https://github.com/Amsterdam/GOB-Core.git@v1.10.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v1.10.1#egg=gobcore

--- a/src/tests/relate/test_init.py
+++ b/src/tests/relate/test_init.py
@@ -148,7 +148,7 @@ class TestInit(TestCase):
             }
         }
         _split_job(msg)
-        mock_logger.info.assert_called_with("Missing relation specification for catalog dst_col attr. Skipping")
+        mock_logger.warning.assert_called_with("Missing relation specification for catalog dst_col attr. Skipping")
 
     @patch("gobupload.relate.datetime")
     @patch("gobupload.relate.GOBModel")


### PR DESCRIPTION
Use warning instead of info, when a relation specification is missing. 
This way it will show up in Iris.

Updated core with new meetbouten relation names