### PR TITLE
Update gobcore. Use pass_args_standalone to explicitly accept the 'mode' parameter

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -43,7 +43,10 @@ SERVICEDEFINITION: ServiceDefinition = {
         'report': {
             'exchange': WORKFLOW_EXCHANGE,
             'key': COMPARE_RESULT_KEY,
-        }
+        },
+        'pass_args_standalone': [
+            'mode',
+        ],
     },
     'full_update': {
         'queue': FULLUPDATE_QUEUE,
@@ -60,7 +63,10 @@ SERVICEDEFINITION: ServiceDefinition = {
         'report': {
             'exchange': WORKFLOW_EXCHANGE,
             'key': RELATE_PREPARE_RESULT_KEY,
-        }
+        },
+        'pass_args_standalone': [
+            'mode',
+        ],
     },
     'relate_process': {
         'queue': RELATE_PROCESS_QUEUE,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 alembic==1.8.1
--e git+https://github.com/Amsterdam/GOB-Core.git@v1.11.2#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@vTODO#egg=gobcore


### PR DESCRIPTION
Needs update of GOB-Core once https://github.com/Amsterdam/GOB-Core/pull/687 is merged