### PR TITLE
Apply event fixes

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -188,8 +188,7 @@ def argument_parser():
 
 
 if DEBUG:
-    # pragma: no cover
-    print("WARNING: Debug mode is ON")
+    print("WARNING: Debug mode is ON")  # pragma: no cover
 
 
 def run_as_message_driven() -> None:

--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -18,10 +18,11 @@ from gobupload.utils import ActiveGarbageCollection, get_event_ids, is_corrupted
 ANALYZE_THRESHOLD = 0.3
 
 
-def apply_events(storage, last_events, start_after, stats):
+def apply_events(storage: GOBStorageHandler, last_events: set[str], start_after: int, stats: UpdateStatistics):
     """Apply any unhandled events to the database
 
     :param storage: GOB (events + entities)
+    :param last_events: all entities with events applied
     :param start_after: the is of the last event that has been applied to the storage
     :param stats: update statitics for this action
     :return:

--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -27,18 +27,11 @@ def apply_events(storage: GOBStorageHandler, last_events: set[str], start_after:
     :param stats: update statitics for this action
     :return:
     """
-    chunksize = 10_000
-    report_per = chunksize * 25
-
-    def log_progress(number: int):
-        if number % report_per == 0 or number % chunksize != 0:
-            logger.info(f"Applied events - {number:,}")
-
     with (
-        ProgressTicker("Apply events", chunksize) as progress,
+        ProgressTicker("Apply events", 10_000) as progress,
         EventApplicator(storage, last_events) as event_applicator,
     ):
-        for chunk in storage.get_events_starting_after(start_after, chunksize):
+        for chunk in storage.get_events_starting_after(start_after):
             for event in chunk:
                 progress.tick()
 
@@ -46,7 +39,6 @@ def apply_events(storage: GOBStorageHandler, last_events: set[str], start_after:
                 stats.add_applied(gob_event.action, count)
 
             event_applicator.apply_all()
-            log_progress(progress._count)
 
 
 def apply_confirm_events(storage, stats, msg):

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -19,7 +19,6 @@ from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import OperationalError, MultipleResultsFound
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.exc import MultipleResultsFound
 
 from gobcore.enum import ImportMode
 from gobcore.exceptions import GOBException
@@ -41,7 +40,7 @@ from gobupload.storage.materialized_views import MaterializedViews
 
 # not used but must be imported
 # https://geoalchemy-2.readthedocs.io/en/latest/core_tutorial.html#reflecting-tables
-from geoalchemy2 import Geometry
+from geoalchemy2 import Geometry  # noqa: F401
 
 
 def with_session(func):

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from typing import Union, Iterator, Iterable
 
 from sqlalchemy import create_engine, Table, update, exc as sa_exc, select, column, String, values
-from sqlalchemy.engine import Connection, Row
+from sqlalchemy.engine import Row
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import OperationalError, MultipleResultsFound
 from sqlalchemy.ext.automap import automap_base
@@ -80,9 +80,21 @@ class StreamSession(SessionORM):
         return {"execution_options": exec_opts, **kwargs}
 
     def stream_scalars(self, statement, **kwargs):
+        """
+        Execute a statement and return the results as scalars.
+        Use a server-side cursor during statement execution to prevent high memory consumption.
+
+        Default batchsize: 1000 (can be adjusted by passing yield_per=<size> to execution_options)
+        """
         return super().scalars(statement, **self._update_param(**kwargs))
 
     def stream_execute(self, statement, **kwargs):
+        """
+        Execute a SQL expression construct.
+        Use a server-side cursor during statement execution to prevent high memory consumption.
+
+        Default batchsize: 1000 (can be adjusted by passing yield_per=<size> to execution_options)
+        """
         return super().execute(statement, **self._update_param(**kwargs))
 
 

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -428,9 +428,9 @@ WHERE
         :param execution_options: options passed to the connection bound to the session
         e.g. 'compile_cache' and 'yield_per'
         """
-        connection = None
+        connection = self.engine.connect()
         if execution_options:
-            connection = self.engine.connect().execution_options(**execution_options)
+            connection = connection.execution_options(**execution_options)
 
         self.session = self.Session(bind=connection)
 

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -71,7 +71,10 @@ def with_session(func):
 class StreamSession(SessionORM):
     """Extended session class with streaming functionality."""
 
-    YIELD_PER = 1_000
+    # tweak this variable for batchsize
+    # higher value leads to more memory allocation per cycle
+    # 200 shows stable memory usage
+    YIELD_PER = 200
 
     def _update_param(self, **kwargs) -> dict[str, dict]:
         exec_opts = kwargs.pop("execution_options", {})
@@ -666,7 +669,6 @@ WHERE
             values(column("_tid", String), name="tids")\
             .data([(tid, ) for tid in tids])
 
-        # Use a join when selecting tids, tids can be of considerable size ( > 1_000_000)
         query = select(self.DbEntity).join(values_tid, self.DbEntity._tid == values_tid.c._tid)
 
         if not with_deleted:

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -552,11 +552,10 @@ WHERE
         :param value: value to loop for, e.g. "DIVA"
         :return: True if any entity exists, else False
         """
-        key_col = getattr(self.DbEntity, key)
         query = select(self.DbEntity).limit(1)
 
         if key and value:
-            query = query.where(key_col == value)
+            query = query.where(getattr(self.DbEntity, key) == value)
         return self.session.execute(query).first() is not None
 
     def get_collection_model(self):

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -111,7 +111,6 @@ class GOBStorageHandler:
         class_=StreamSession
     )
     base = None
-    added_session_entity_cnt = 0
 
     @classmethod
     def _set_base(cls, update=False):
@@ -125,7 +124,6 @@ class GOBStorageHandler:
 
     EVENTS_TABLE = "events"
     ALL_TABLES = [EVENTS_TABLE] + gob_model.get_table_names()
-    FORCE_FLUSH_PER = 10000
 
     user_name = f"({GOB_DB['username']}@{GOB_DB['host']}:{GOB_DB['port']})"
 
@@ -795,14 +793,8 @@ VALUES {values}"""
         result.close()
 
     @with_session
-    def _flush_entities(self):
-        if self.added_session_entity_cnt >= self.FORCE_FLUSH_PER:
-            self.force_flush_entities()
-
-    @with_session
     def force_flush_entities(self):
         self.session.flush()
-        self.added_session_entity_cnt = 0
 
     def execute(self, statement):
         result = self.engine.execute(statement)

--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -13,7 +13,7 @@ from gobupload.storage.handler import GOBStorageHandler
 
 class EventApplicator:
     MAX_ADD_CHUNK = 10_000
-    MAX_OTHER_CHUNK = 2_500
+    MAX_OTHER_CHUNK = 10_000
 
     def __init__(self, storage: GOBStorageHandler, last_events: set[str], add_event_tids: set[str]):
         self.storage = storage
@@ -104,7 +104,7 @@ class EventApplicator:
         """
         for gob_event in self.other_events.pop(entity._tid):
             # Check action validity
-            if entity._date_deleted is not None and not isinstance(gob_event, GOB.ADD):
+            if not isinstance(gob_event, GOB.ADD) and entity._date_deleted is not None:
                 # a non-ADD event is trying to be applied on a deleted entity
                 # Only ADD event can be applied on a deleted entity
                 raise GOBException(f"Trying to '{gob_event.name}' a deleted entity (id: {gob_event.id}, "

--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -12,10 +12,8 @@ from gobupload.storage.handler import GOBStorageHandler
 
 
 class EventApplicator:
-    MAX_ADD_CHUNK = 10_000
-    MAX_OTHER_CHUNK = 10_000
 
-    def __init__(self, storage: GOBStorageHandler, last_events: set[str], add_event_tids: set[str]):
+    def __init__(self, storage: GOBStorageHandler, last_events: set[str]):
         self.storage = storage
 
         self.add_events = []
@@ -23,69 +21,41 @@ class EventApplicator:
         self.other_events_sum = 0
 
         self.last_events = last_events
-        self.add_event_tids = add_event_tids
+        self.add_event_tids = set()
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        # Write any buffered entities and flush storage
         if self.add_events or self.other_events:
             raise GOBException("Have unapplied events. Call apply_all() before leaving context")
-        self.storage.force_flush_entities()
 
     def add_add_event(self, event):
-        """Adds add event to buffer, applies pending add events when buffer is full.
-        Returns the list of applied events.
-
-        :param event:
-        :return:
-        """
+        """Adds ADD event to buffer."""
         self.add_events.append(event)
 
-        if len(self.add_events) >= self.MAX_ADD_CHUNK:
-            self.apply_add_events()
-
     def apply_add_events(self):
-        """Applies add events in buffer.
-        Returns the list of applied events
-
-        :return:
-        """
+        """Applies ADD events in buffer and clears afterwards."""
         if self.add_events:
             self.storage.add_add_events(self.add_events)
             self.add_events.clear()
 
     def add_other_event(self, gob_event, tid):
-        """
-        Add a non-ADD event, or an ADD event on a deleted entity
-        If MAX_OTHER_CHUNK events have been buffered then mass-apply the events
-
-        Returns the list of applied events
-
-        :param gob_event:
-        :param data:
-        :return:
-        """
+        """Add a non-ADD event or an ADD event on a deleted entity."""
         self.other_events[tid].append(gob_event)
         self.other_events_sum += 1
 
-        if self.other_events_sum >= self.MAX_OTHER_CHUNK:
-            self.apply_other_events()
-
     def apply_other_events(self):
         """
-        Mass-Apply events
-
-        Returns the list of applied events
-
-        :return:
+        Mass-Apply events in buffer and clear them afterwards.
+        Initialise a session when applying and close to flush
         """
         if self.other_events:
-            entities = self.storage.get_entities(self.other_events.keys(), with_deleted=True)
+            with self.storage.get_session():
+                entities = self.storage.get_entities(self.other_events.keys(), with_deleted=True)
 
-            for entity in entities:
-                self.apply_other_event(entity)
+                for entity in entities:
+                    self.apply_other_event(entity)
 
             self.other_events.clear()
             self.other_events_sum = 0
@@ -100,7 +70,6 @@ class EventApplicator:
         - CONFIRM event (these event only set the last modified date, not the last event id)
 
         :param entity:
-        :return:
         """
         for gob_event in self.other_events.pop(entity._tid):
             # Check action validity

--- a/src/gobupload/update/event_applicator.py
+++ b/src/gobupload/update/event_applicator.py
@@ -15,7 +15,7 @@ class EventApplicator:
     MAX_ADD_CHUNK = 10_000
     MAX_OTHER_CHUNK = 2_500
 
-    def __init__(self, storage: GOBStorageHandler, last_events: set[int], add_event_tids: set[str]):
+    def __init__(self, storage: GOBStorageHandler, last_events: set[str], add_event_tids: set[str]):
         self.storage = storage
 
         self.add_events = []

--- a/src/gobupload/update/update_statistics.py
+++ b/src/gobupload/update/update_statistics.py
@@ -6,7 +6,7 @@ Gathers statistices about the update process
 from gobcore.logging.logger import logger
 
 
-class UpdateStatistics():
+class UpdateStatistics:
 
     def __init__(self):
         self.stored = {}
@@ -31,7 +31,7 @@ class UpdateStatistics():
         else:
             return 1
 
-    def _action(selfself, event):
+    def _action(self, event):
         action = event["event"]
         if action == "BULKCONFIRM":
             action = "CONFIRM"

--- a/src/gobupload/update/update_statistics.py
+++ b/src/gobupload/update/update_statistics.py
@@ -3,15 +3,17 @@ Update statistics
 
 Gathers statistices about the update process
 """
+from collections import defaultdict
+
 from gobcore.logging.logger import logger
 
 
 class UpdateStatistics:
 
     def __init__(self):
-        self.stored = {}
-        self.skipped = {}
-        self.applied = {}
+        self.stored = defaultdict(int)
+        self.skipped = defaultdict(int)
+        self.applied = defaultdict(int)
         self.num_events = 0
         self.num_single_events = 0
         self.num_bulk_events = 0
@@ -39,16 +41,16 @@ class UpdateStatistics:
 
     def store_event(self, event):
         action = self._action(event)
-        self.stored[action] = self.stored.get(action, 0) + self._count(event)
+        self.stored[action] += self._count(event)
         self._update_counts(event)
 
     def skip_event(self, event):
         action = self._action(event)
-        self.skipped[action] = self.skipped.get(action, 0) + self._count(event)
+        self.skipped[action] += self._count(event)
         self._update_counts(event)
 
     def add_applied(self, action, count):
-        self.applied[action] = self.applied.get(action, 0) + count
+        self.applied[action] += count
 
     def results(self):
         """Get statistics in a dictionary

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -40,7 +40,6 @@ class TestApply(TestCase):
         stats = MagicMock()
 
         apply_events(self.mock_storage, {}, 1, stats)
-        self.mock_storage.get_session.return_value.__enter__.return_value.expunge.assert_called_with(event)
 
         stats.add_applied.assert_called()
 

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -36,10 +36,10 @@ class TestApply(TestCase):
         event = fixtures.get_event_fixure()
         event.contents = '{"_entity_source_id": "{fixtures.random_string()}", "entity": {}}'
         mock.return_value = self.mock_storage
-        self.mock_storage.get_events_starting_after.side_effect = [[event], []]
+        self.mock_storage.get_events_starting_after.side_effect = [[[event]], []]
         stats = MagicMock()
 
-        apply_events(self.mock_storage, {}, 1, stats)
+        apply_events(self.mock_storage, set(), 1, stats)
 
         stats.add_applied.assert_called()
 

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import call, MagicMock, patch, PropertyMock
+from unittest.mock import call, MagicMock, patch
 
 from sqlalchemy import Integer, DateTime, String, JSON
 from sqlalchemy.orm import declarative_base

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -1,10 +1,14 @@
 import unittest
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, MagicMock, patch, PropertyMock
+
+from sqlalchemy import Integer, DateTime, String, JSON
+from sqlalchemy.orm import declarative_base
 
 from gobcore.events.import_message import ImportMessage
 from gobcore.exceptions import GOBException
 
 from sqlalchemy.exc import OperationalError
+import sqlalchemy as sa
 
 from gobupload.compare.populate import Populator
 from gobupload.storage import queries
@@ -28,6 +32,25 @@ class MockedEngine:
 
     def __exit__(self, *args):
         pass
+
+
+Base = declarative_base()
+
+
+class MockEvents(Base):
+    __tablename__ = "events"
+
+    eventid = sa.Column(Integer, primary_key=True)
+    timestamp = sa.Column(DateTime)
+    catalogue = sa.Column(String)
+    entity = sa.Column(String)
+    version = sa.Column(String)
+    action = sa.Column(String)
+    source = sa.Column(String)
+    source_id = sa.Column(String)
+    contents = sa.Column(JSON)
+    application = sa.Column(String)
+    tid = sa.Column(String)
 
 
 class TestStorageHandler(unittest.TestCase):
@@ -55,6 +78,8 @@ class TestStorageHandler(unittest.TestCase):
         GOBStorageHandler.engine.__enter__ = lambda self: None
         GOBStorageHandler.engine.__exit__ = lambda *args: None
         GOBStorageHandler.engine.begin = lambda: GOBStorageHandler.engine
+
+        GOBStorageHandler.base.classes.events = MockEvents
 
     @patch("gobupload.storage.handler.automap_base", MagicMock())
     def test_base(self):
@@ -358,14 +383,33 @@ WHERE
     def test_combinations_plain(self):
         mock_session = MagicMock()
         self.storage.get_session = mock_session
+
         result = self.storage.get_source_catalogue_entity_combinations()
-        mock_session.return_value.__enter__().execute.assert_called_with('SELECT DISTINCT source, catalogue, entity FROM events')
+        self.assertIsInstance(result, list)
+
+        query = mock_session.return_value.__enter__().stream_execute.call_args[0][0]
+        query = str(query.compile(compile_kwargs={"literal_binds": True}))
+        self.assertEqual(
+            "SELECT DISTINCT events.source, events.catalogue, events.entity \n"
+            "FROM events",
+            query
+        )
 
     def test_combinations_with_args(self):
         mock_session = MagicMock()
         self.storage.get_session = mock_session
-        result = self.storage.get_source_catalogue_entity_combinations(col="val")
-        mock_session.return_value.__enter__().execute.assert_called_with("SELECT DISTINCT source, catalogue, entity FROM events WHERE col = 'val'")
+
+        result = self.storage.get_source_catalogue_entity_combinations(source="val")
+        self.assertIsInstance(result, list)
+
+        query = mock_session.return_value.__enter__().stream_execute.call_args[0][0]
+        query = str(query.compile(compile_kwargs={"literal_binds": True}))
+        self.assertEqual(
+            "SELECT DISTINCT events.source, events.catalogue, events.entity \n"
+            "FROM events \n"
+            "WHERE events.source = 'val'",
+            query
+        )
 
     @patch('gobupload.storage.handler.gob_model.get_table_name')
     def test_get_tablename(self, mock_get_table_name):

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -360,21 +360,6 @@ WHERE
         expect = f"DELETE FROM {events} WHERE catalogue = '{catalogue}' AND entity = '{entity}' AND action IN ('BULKCONFIRM', 'CONFIRM')"
         self.assertEqual(args, expect)
 
-    def test_flush_entities(self):
-        self.storage.session = MagicMock()
-
-        self.storage.FORCE_FLUSH_PER = 5
-        self.storage.added_session_entity_cnt = 4
-
-        self.storage._flush_entities()
-        self.storage.session.flush.assert_not_called()
-        self.assertEqual(4, self.storage.added_session_entity_cnt)
-
-        self.storage.added_session_entity_cnt = 5
-        self.storage._flush_entities()
-        self.storage.session.flush.assert_called_once()
-        self.assertEqual(0, self.storage.added_session_entity_cnt)
-
     def test_get_query_value(self):
         self.storage.get_query_value('SELECT * FROM test')
         # Assert the query is performed

--- a/src/tests/storage/test_storage.py
+++ b/src/tests/storage/test_storage.py
@@ -1,10 +1,10 @@
 import importlib
 import unittest
-from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from gobcore.exceptions import GOBException
 
-from gobupload.storage.handler import with_session, GOBStorageHandler
+from gobupload.storage.handler import with_session
 from gobupload.storage import handler
 from tests import fixtures
 
@@ -38,7 +38,7 @@ class TestContextManager(unittest.TestCase):
         # patch __init__, we don't test that here, but we need session and engine to be present
         def side_effect(self, param):
             self.session = None
-            self.engine = None
+            self.engine = MagicMock()
         handler.GOBStorageHandler.__init__ = side_effect
 
     def tearDown(self):
@@ -46,7 +46,7 @@ class TestContextManager(unittest.TestCase):
         importlib.reload(handler)
 
     def test_session_context(self):
-        mock_session = mock.MagicMock()
+        mock_session = MagicMock()
         handler.GOBStorageHandler.Session = mock_session
         storage = handler.GOBStorageHandler(fixtures.random_string())
 
@@ -54,15 +54,42 @@ class TestContextManager(unittest.TestCase):
         self.assertIsNone(storage.session)
 
         # prepare mock
-        mock_session_instance = mock.MagicMock()
+        mock_session_instance = MagicMock()
         mock_session.return_value = mock_session_instance
 
         # test session creation in context
-        with storage.get_session():
-            mock_session.assert_called_with()
+        with storage.get_session() as session:
+            mock_session.assert_called_with(bind=None)
             self.assertEqual(storage.session, mock_session_instance)
+            self.assertEqual(session, mock_session_instance)
 
         # test session creation after leaving context:
+        mock_session_instance.flush.assert_called()
         mock_session_instance.close.assert_called()
         self.assertIsNone(storage.session)
 
+        # test exception handling
+        with patch("gobupload.storage.handler.logger") as mock_logger:
+            with storage.get_session():
+                raise ConnectionError("any")
+
+        mock_session_instance.rollback.assert_called()
+        mock_session_instance.close.assert_called()
+        mock_logger.error.assert_called_with("ConnectionError('any')")
+
+    def test_session_context_execution_options(self):
+        mock_session = MagicMock()
+        handler.GOBStorageHandler.Session = mock_session
+        storage = handler.GOBStorageHandler(fixtures.random_string())
+
+        mock_conn = MagicMock()
+        storage.engine.connect.return_value.execution_options.return_value = mock_conn
+
+        mock_session_instance = MagicMock()
+
+        with storage.get_session(compile_cache=None) as session:
+            storage.engine.connect.return_value.execution_options.assert_called_with(compile_cache=None)
+
+            mock_session.assert_called_with(bind=mock_conn)
+            self.assertEqual(storage.session, mock_session_instance)
+            self.assertEqual(session, mock_session_instance)

--- a/src/tests/update/test_event_applicator.py
+++ b/src/tests/update/test_event_applicator.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import json
 from gobcore.events import GOB
 from gobcore.exceptions import GOBException
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from gobupload.storage.handler import GOBStorageHandler
 from gobupload.update.event_applicator import EventApplicator
@@ -34,18 +34,22 @@ class TestEventApplicator(TestCase):
         self.mock_event["contents"] = json.dumps(contents)
 
     def test_constructor(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set("1"), set("2"))
         self.assertEqual(applicator.add_events, [])
+        self.assertDictEqual(applicator.other_events, {})
+        self.assertEqual(applicator.other_events_sum, 0)
+        self.assertEqual(applicator.last_events, set("1"))
+        self.assertEqual(applicator.add_event_tids, set("2"))
 
     def test_apply(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set(), set())
         self.mock_event["action"] = 'CONFIRM'
         self.set_contents({
             '_tid': 'entity_source_id',
             '_hash': '123'
         })
         event = dict_to_object(self.mock_event)
-        applicator.apply(event, {}, set())
+        applicator.apply(event)
         self.assertEqual(len(applicator.add_events), 0)
         self.assertEqual(len(applicator.other_events), 1)
 
@@ -55,10 +59,28 @@ class TestEventApplicator(TestCase):
             '_hash': '123'
         })
         event = dict_to_object(self.mock_event)
-        with EventApplicator(self.storage) as applicator:
-            applicator.apply(event, dict(), set())
+        with EventApplicator(self.storage, set(), set()) as applicator:
+            applicator.apply(event)
             self.assertEqual(len(applicator.add_events), 1)
             applicator.apply_all()
+        self.assertEqual(len(applicator.add_events), 0)
+        self.storage.add_add_events.assert_called()
+
+    def test_apply_add_max_chunk(self):
+        self.set_contents({
+            '_tid': 'entity_source_id',
+            '_hash': '123'
+        })
+        event = dict_to_object(self.mock_event)
+
+        with (
+            EventApplicator(self.storage, set(), set()) as applicator,
+            patch.object(applicator, "MAX_ADD_CHUNK", 1)
+        ):
+            applicator.MAX_ADD_CHUNK = 1
+
+            applicator.apply(event)
+
         self.assertEqual(len(applicator.add_events), 0)
         self.storage.add_add_events.assert_called()
 
@@ -69,8 +91,8 @@ class TestEventApplicator(TestCase):
         })
         event = dict_to_object(self.mock_event)
         with self.assertRaises(GOBException):
-            with EventApplicator(self.storage) as applicator:
-                applicator.apply(event, dict(), set())
+            with EventApplicator(self.storage, set(), set()) as applicator:
+                applicator.apply(event)
 
     def test_apply_existing_add(self):
         # Expect add event for existing deleted entity leads to add other event
@@ -80,18 +102,18 @@ class TestEventApplicator(TestCase):
         event = dict_to_object(self.mock_event)
         event.tid = 'existing_source_id'
 
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, {'existing_source_id'}, set())
         applicator.add_add_event = MagicMock()
         applicator.apply_add_events = MagicMock()
         applicator.add_other_event = MagicMock()
-        applicator.apply(event, {'existing_source_id': 'any event id'}, set())
+        applicator.apply(event)
 
         applicator.add_add_event.assert_not_called()
         applicator.apply_add_events.assert_called_once()
         applicator.add_other_event.assert_called_once()
 
     def test_apply_bulk(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set(), set())
         self.mock_event["action"] = 'BULKCONFIRM'
         self.set_contents({
             'confirms': [{
@@ -99,12 +121,12 @@ class TestEventApplicator(TestCase):
             }]
         })
         event = dict_to_object(self.mock_event)
-        applicator.apply(event, dict(), set())
+        applicator.apply(event)
         self.assertEqual(len(applicator.add_events), 0)
         self.storage.bulk_update_confirms.assert_called()
 
     def test_add_other_event(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set(), set())
 
         applicator.MAX_OTHER_CHUNK = 3
         applicator.apply_other_events = MagicMock()
@@ -121,7 +143,7 @@ class TestEventApplicator(TestCase):
         applicator.apply_other_events.assert_called()
 
     def test_apply_other_events(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set(), set())
         applicator.apply_other_event = MagicMock()
 
         self.assertEqual(applicator.other_events, {})
@@ -142,7 +164,7 @@ class TestEventApplicator(TestCase):
         applicator.apply_other_event.assert_called_with('any entity')
 
     def test_apply_other_event(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set(), set())
 
         entity = MagicMock()
         entity._date_deleted = None
@@ -183,7 +205,7 @@ class TestEventApplicator(TestCase):
         self.assertEqual(entity._last_event, None)
 
     def test_apply_all(self):
-        applicator = EventApplicator(self.storage)
+        applicator = EventApplicator(self.storage, set(), set())
         applicator.apply_add_events = MagicMock()
         applicator.apply_other_events = MagicMock()
         applicator.apply_all()
@@ -197,7 +219,8 @@ class TestEventApplicator(TestCase):
         We expect the second ADD event to be handled as an 'other' event, because it needs to revive the deleted
         entity.
         """
-        applicator = EventApplicator(self.storage)
+        add_event_source_ids = set()
+        applicator = EventApplicator(self.storage, set(), add_event_source_ids)
 
         test_events = [
             {'action': 'ADD', 'contents': {'_tid': 'any source id'}},
@@ -207,12 +230,11 @@ class TestEventApplicator(TestCase):
 
         test_gob_events = []
 
-        add_event_source_ids = set()
         for event in test_events:
             self.mock_event['action'] = event['action']
             self.set_contents(event['contents'])
             event_object = dict_to_object(self.mock_event)
-            gob_event, *_ = applicator.apply(event_object, dict(), add_event_source_ids)
+            gob_event, *_ = applicator.apply(event_object)
             test_gob_events.append(gob_event)
 
         # Expect the first add event to be applied, and a DELETE and ADD event in other events
@@ -228,7 +250,8 @@ class TestEventApplicator(TestCase):
         Test if a batch of events multiple MODIFY events of the same entity is handled correctly.
         We expect the all modify events to be applied
         """
-        applicator = EventApplicator(self.storage)
+        add_event_source_ids = set()
+        applicator = EventApplicator(self.storage, set(), add_event_source_ids)
 
         test_events = [
             {'action': 'MODIFY', 'contents': {'_tid': 'any source id'}},
@@ -238,12 +261,11 @@ class TestEventApplicator(TestCase):
 
         test_gob_events = []
 
-        add_event_source_ids = set()
         for event in test_events:
             self.mock_event['action'] = event['action']
             self.set_contents(event['contents'])
             event_object = dict_to_object(self.mock_event)
-            gob_event, *_ = applicator.apply(event_object, dict(), add_event_source_ids)
+            gob_event, *_ = applicator.apply(event_object)
             test_gob_events.append(gob_event)
 
         # Expect all 3 modify events to be added to other events

--- a/src/tests/update/test_event_applicator.py
+++ b/src/tests/update/test_event_applicator.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 import json
 from gobcore.events import GOB
 from gobcore.exceptions import GOBException
-from unittest.mock import MagicMock, ANY
+from unittest.mock import MagicMock
 
 from gobupload.storage.handler import GOBStorageHandler
 from gobupload.update.event_applicator import EventApplicator
@@ -103,62 +103,21 @@ class TestEventApplicator(TestCase):
         self.assertEqual(len(applicator.add_events), 0)
         self.storage.bulk_update_confirms.assert_called()
 
-    def test_apply_return_values(self):
-        """This method tests that all applied events are correctly returned from apply
-
-        :return:
-        """
-        applicator = EventApplicator(self.storage)
-        applicator.add_add_event = MagicMock(return_value=['applied event1', 'applied event2'])
-        applicator.apply_add_events = MagicMock(return_value=['applied event3', 'applied event4'])
-        applicator.add_other_event = MagicMock(return_value=['applied event5', 'applied event6'])
-
-        # BULKCONFIRM
-        self.set_contents({
-            'confirms': [{
-                '_tid': 'entity_source_id'
-            }]
-        })
-        self.mock_event['action'] = 'BULKCONFIRM'
-        event = dict_to_object(self.mock_event)
-        self.assertEqual((ANY, 1, []), applicator.apply(event, dict(), set()))
-
-        # ADD
-        self.set_contents({
-            '_tid': 'entity_source_id',
-            '_hash': '123'
-        })
-        self.mock_event['action'] = 'ADD'
-        event = dict_to_object(self.mock_event)
-        self.assertEqual((ANY, 1, ['applied event1', 'applied event2']), applicator.apply(event, dict(), set()))
-
-        # CONFIRM (other)
-        self.mock_event["action"] = 'CONFIRM'
-        self.set_contents({
-            '_tid': 'entity_source_id',
-            '_hash': '123'
-        })
-        event = dict_to_object(self.mock_event)
-        self.assertEqual(
-            (ANY, 1, ['applied event3', 'applied event4', 'applied event5', 'applied event6']),
-            applicator.apply(event, dict(), set()))
-
     def test_add_other_event(self):
         applicator = EventApplicator(self.storage)
 
         applicator.MAX_OTHER_CHUNK = 3
         applicator.apply_other_events = MagicMock()
 
-        self.assertEqual([],
-                         applicator.add_other_event('any gob event1',  'any entity source 1'))
+        applicator.add_other_event('any gob event1',  'any entity source 1')
+        applicator.apply_other_events.assert_not_called()
         self.assertEqual(applicator.other_events['any entity source 1'], ['any gob event1'])
 
-        self.assertEqual([],
-                         applicator.add_other_event('any gob event2', 'any entity source 2'))
+        applicator.add_other_event('any gob event2', 'any entity source 2')
         applicator.apply_other_events.assert_not_called()
+        self.assertEqual(applicator.other_events['any entity source 2'], ['any gob event2'])
 
-        self.assertEqual(applicator.apply_other_events.return_value,
-                         applicator.add_other_event('any gob event3', 'any entity source 3'))
+        applicator.add_other_event('any gob event3', 'any entity source 3')
         applicator.apply_other_events.assert_called()
 
     def test_apply_other_events(self):
@@ -167,15 +126,18 @@ class TestEventApplicator(TestCase):
 
         self.assertEqual(applicator.other_events, {})
 
-        self.assertEqual([], applicator.apply_other_events())
+        applicator.apply_other_events()
+
         self.assertEqual(applicator.other_events, {})
+        self.assertEqual(applicator.other_events_sum, 0)
         self.storage.get_entities.assert_not_called()
 
         applicator.add_other_event('any gob event', 'any entity source id')
         self.storage.get_entities.return_value = ['any entity']
 
-        self.assertEqual(['any gob event'], applicator.apply_other_events())
+        applicator.apply_other_events()
         self.assertEqual(applicator.other_events, {})
+        self.assertEqual(applicator.other_events_sum, 0)
         self.storage.get_entities.assert_called()
         applicator.apply_other_event.assert_called_with('any entity')
 
@@ -198,6 +160,7 @@ class TestEventApplicator(TestCase):
         self.assertEqual(entity._last_event, gob_event.id)
 
         # Apply NON-ADD event on a deleted entity
+        applicator.other_events['any source id'] = [gob_event]
         entity._date_deleted = 'any date deleted'
         with self.assertRaises(GOBException):
             applicator.apply_other_event(entity)
@@ -221,10 +184,10 @@ class TestEventApplicator(TestCase):
 
     def test_apply_all(self):
         applicator = EventApplicator(self.storage)
-        applicator.apply_add_events = MagicMock(return_value=[1, 2])
-        applicator.apply_other_events = MagicMock(return_value=[3])
+        applicator.apply_add_events = MagicMock()
+        applicator.apply_other_events = MagicMock()
+        applicator.apply_all()
 
-        self.assertEqual([1, 2, 3], applicator.apply_all())
         applicator.apply_add_events.assert_called_once()
         applicator.apply_other_events.assert_called_once()
 
@@ -253,10 +216,12 @@ class TestEventApplicator(TestCase):
             test_gob_events.append(gob_event)
 
         # Expect the first add event to be applied, and a DELETE and ADD event in other events
-        self.storage.add_add_events.assert_called_with(test_gob_events[:1])
+        # we can't check the parameter, which is removed by self.add_events.clear()
+        self.storage.add_add_events.assert_called_once()
         self.assertEqual(len(applicator.add_events), 0)
-        print(applicator.other_events)
-        self.assertEqual(sum([len(x) for x in applicator.other_events.values()]), 2)
+
+        self.assertEqual(applicator.other_events["tid"], test_gob_events[1:])
+        self.assertEqual(applicator.other_events_sum, 2)
 
     def test_apply_event_batch_modifies(self):
         """


### PR DESCRIPTION
Main purpose of this PR is to use server-side cursor during the `apply` workflow.
Fixed some other things along the way.

- Rewrote queries using new sqlalchemy style (select() instead of query())
- Added limit(1) to .first() queries, only 1 row needed
- Added StreamSession to add `stream_execute` and `stream_scalars` functions
- Use StreamSession to fetch all the events instead of pagination
- During standalone mode, we need to log with log.error. Otherwise the program exits 0
- Removed returned applied events (not used anymore)
- ActiveGarbageCollection not needed anymore

Fixed [AB#64420](https://dev.azure.com/CloudCompetenceCenter/7755cdf4-1859-48c5-b954-fd6c8e46fe52/_workitems/edit/64420)