### PR TITLE
In standalone mode, don't migrate as default

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -218,17 +218,14 @@ def run_as_message_driven() -> None:
 
 
 def run_as_standalone(args: argparse.Namespace) -> int:
-    storage = GOBStorageHandler()
-
     if args.handler == "migrate":
         mviews = args.materialized_views
-        storage.init_storage(
+        GOBStorageHandler().init_storage(
             force_migrate=True,
             recreate_materialized_views=[args.mv_name] if mviews and args.mv_name else mviews
         )
         return os.EX_OK
 
-    storage.init_storage()
     return standalone.run_as_standalone(args, SERVICEDEFINITION)
 
 

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -76,9 +76,9 @@ class TestMain(TestCase):
             recreate_materialized_views=['some_mv_name']
         )
 
-    @mock.patch('gobupload.__main__.GOBStorageHandler', mock.MagicMock())
+    @mock.patch('gobupload.__main__.GOBStorageHandler')
     @mock.patch('gobupload.__main__.standalone.run_as_standalone', return_value=0)
-    def test_main_calls_run_as_standalone(self, mock_run_as_standalone):
+    def test_main_calls_run_as_standalone(self, mock_run_as_standalone, mock_storage):
         # No command line arguments
         sys.argv = [
             'python -m gobupload',
@@ -89,16 +89,14 @@ class TestMain(TestCase):
         with self.assertRaisesRegex(SystemExit, "0"):
             main()
 
+        mock_storage.assert_not_called()
         mock_run_as_standalone.assert_called()
 
     @mock.patch('gobupload.__main__.GOBStorageHandler')
     @mock.patch('gobupload.__main__.standalone.run_as_standalone')
     def test_standalone_migration_error(self, mock_run_as_standalone, mock_storage):
         sys.argv = [
-            'python -m gobupload',
-            'apply',
-            '--catalogue', 'test_catalogue',
-            '--collection', 'test_entity_autoid'
+            'python -m gobupload', 'migrate',
         ]
         mock_storage.side_effect = Exception("my error")
 


### PR DESCRIPTION
Instead make an explicit call to the `migrate` handler in a seperate job