### PR TITLE
Apply event fixes (#1011)

### DIFF
--- a/src/gobupload/__main__.py
+++ b/src/gobupload/__main__.py
@@ -188,8 +188,7 @@ def argument_parser():
 
 
 if DEBUG:
-    # pragma: no cover
-    print("WARNING: Debug mode is ON")
+    print("WARNING: Debug mode is ON")  # pragma: no cover
 
 
 def run_as_message_driven() -> None:

--- a/src/gobupload/update/update_statistics.py
+++ b/src/gobupload/update/update_statistics.py
@@ -3,15 +3,17 @@ Update statistics
 
 Gathers statistices about the update process
 """
+from collections import defaultdict
+
 from gobcore.logging.logger import logger
 
 
-class UpdateStatistics():
+class UpdateStatistics:
 
     def __init__(self):
-        self.stored = {}
-        self.skipped = {}
-        self.applied = {}
+        self.stored = defaultdict(int)
+        self.skipped = defaultdict(int)
+        self.applied = defaultdict(int)
         self.num_events = 0
         self.num_single_events = 0
         self.num_bulk_events = 0
@@ -31,7 +33,7 @@ class UpdateStatistics():
         else:
             return 1
 
-    def _action(selfself, event):
+    def _action(self, event):
         action = event["event"]
         if action == "BULKCONFIRM":
             action = "CONFIRM"
@@ -39,16 +41,16 @@ class UpdateStatistics():
 
     def store_event(self, event):
         action = self._action(event)
-        self.stored[action] = self.stored.get(action, 0) + self._count(event)
+        self.stored[action] += self._count(event)
         self._update_counts(event)
 
     def skip_event(self, event):
         action = self._action(event)
-        self.skipped[action] = self.skipped.get(action, 0) + self._count(event)
+        self.skipped[action] += self._count(event)
         self._update_counts(event)
 
     def add_applied(self, action, count):
-        self.applied[action] = self.applied.get(action, 0) + count
+        self.applied[action] += count
 
     def results(self):
         """Get statistics in a dictionary

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -36,11 +36,10 @@ class TestApply(TestCase):
         event = fixtures.get_event_fixure()
         event.contents = '{"_entity_source_id": "{fixtures.random_string()}", "entity": {}}'
         mock.return_value = self.mock_storage
-        self.mock_storage.get_events_starting_after.side_effect = [[event], []]
+        self.mock_storage.get_events_starting_after.side_effect = [[[event]], []]
         stats = MagicMock()
 
-        apply_events(self.mock_storage, {}, 1, stats)
-        self.mock_storage.get_session.return_value.__enter__.return_value.expunge.assert_called_with(event)
+        apply_events(self.mock_storage, set(), 1, stats)
 
         stats.add_applied.assert_called()
 


### PR DESCRIPTION
* Optimize apply_events

- Narrow session scope
- Remove unused returned events
- Use counter on other_events instead of calculating on every event

* Small fixes for `handler.py`

- according to doc geoalchemy2 must be imported when reflecting database
- correct import MultipleResultsFound
- use comprehension in add_add_events
- set query_size_cache to 250 to limit sqlalchemy cache use

* Use `self` in update_statistics.py

* Fix flake8 import in handler.py

* Add StreamSession class

* Add limit when querying with first()

* Add tests for handler.py and storage.py

* Add tests event_applicator.py and handler.py

* Add docstring + remove unused import

* Fix initialising connection for session

* Optimize yield_per size for memory

* Fix column attr get in case of None

* Remove legacy flush function

* Use `defaultdict` for default value

* Use streaming events instead of pagination

* Set `YIELD_PER` to 2000

- Also use YIELD_PER as the batchsize in returning chunks of events.
- Remove logger call