### PR TITLE
Exclude dropping citus views during migrations

### DIFF
--- a/src/alembic/versions/0ce50938f539_gebieden_begin_eind_geldigheid_datetime.py
+++ b/src/alembic/versions/0ce50938f539_gebieden_begin_eind_geldigheid_datetime.py
@@ -35,7 +35,8 @@ def upgrade():
             and viewowner NOT IN ('postgres', 'azure_superuser')
             and viewname NOT IN (
             'geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews'
-            );
+            )
+            and viewname NOT LIKE 'citus_%';
     BEGIN
         FOR v in c_views LOOP
             EXECUTE 'DROP VIEW IF EXISTS ' || v.viewname || ' CASCADE';

--- a/src/alembic/versions/529e01408f26_integer_volgnummer.py
+++ b/src/alembic/versions/529e01408f26_integer_volgnummer.py
@@ -38,7 +38,8 @@ BEGIN
             viewname NOT LIKE 'geography%' AND
             viewname NOT LIKE 'raster%'    AND
             viewname NOT LIKE 'geometry%'  AND
-            viewname NOT LIKE 'pg_%'
+            viewname NOT LIKE 'pg_%'       AND
+            viewname NOT LIKE 'citus_%'
     LOOP
         EXECUTE 'DROP VIEW ' || t.viewname;
     END LOOP;	


### PR DESCRIPTION
If the citus extension is installed, skip dropping all view which start with citus_ to pass migrations