### PR TITLE
Use TEMPORARY table for compare

### DIFF
--- a/src/gobupload/compare/entity_collector.py
+++ b/src/gobupload/compare/entity_collector.py
@@ -13,10 +13,8 @@ class EntityCollector:
         :param storage:
         """
         self.storage = storage
-        self.tmp_table_name = self.storage.create_temporary_table()
-
-    def close(self):
-        self.storage.close_temporary_table()
+        self._entities = []
+        self.storage.create_temporary_table()
 
     def collect(self, entity):
         """
@@ -24,4 +22,12 @@ class EntityCollector:
         :param entity:
         :return:
         """
-        self.storage.write_temporary_entity(entity)
+        self._entities.append(entity)
+
+        if len(self._entities) >= 10_000:
+            self.storage.write_temporary_entities(self._entities)
+            self._entities.clear()
+
+    def close(self):
+        if self._entities:
+            self.storage.write_temporary_entities(self._entities)

--- a/src/gobupload/compare/entity_collector.py
+++ b/src/gobupload/compare/entity_collector.py
@@ -14,7 +14,12 @@ class EntityCollector:
         """
         self.storage = storage
         self._entities = []
-        self.storage.create_temporary_table()
+        storage.create_temporary_table()
+
+    def _write_entities(self):
+        if self._entities:
+            self.storage.write_temporary_entities(self._entities)
+            self._entities.clear()
 
     def collect(self, entity):
         """
@@ -25,9 +30,8 @@ class EntityCollector:
         self._entities.append(entity)
 
         if len(self._entities) >= 10_000:
-            self.storage.write_temporary_entities(self._entities)
-            self._entities.clear()
+            self._write_entities()
 
     def close(self):
-        if self._entities:
-            self.storage.write_temporary_entities(self._entities)
+        self._write_entities()
+        self.storage.analyze_temporary_table()

--- a/src/gobupload/compare/entity_collector.py
+++ b/src/gobupload/compare/entity_collector.py
@@ -7,6 +7,8 @@ Stores each new entity in a temporary table
 
 class EntityCollector:
 
+    CHUNKSIZE = 10_000
+
     def __init__(self, storage):
         """
         A storage is required to create the temporary table and write the entities to it
@@ -16,10 +18,13 @@ class EntityCollector:
         self._entities = []
         storage.create_temporary_table()
 
+    def _clear(self):
+        self._entities.clear()
+
     def _write_entities(self):
         if self._entities:
             self.storage.write_temporary_entities(self._entities)
-            self._entities.clear()
+            self._clear()
 
     def collect(self, entity):
         """
@@ -29,7 +34,7 @@ class EntityCollector:
         """
         self._entities.append(entity)
 
-        if len(self._entities) >= 10_000:
+        if len(self._entities) >= self.CHUNKSIZE:
             self._write_entities()
 
     def close(self):

--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -47,54 +47,54 @@ def compare(msg):
 
     stats = CompareStatistics()
 
-    tmp_table_name = None
-    with storage.get_session():
-        with ProgressTicker("Collect compare events", 10000) as progress:
-            # Check any dependencies
-            if not meets_dependencies(storage, msg):
-                return {
-                    "header": msg["header"],
-                    "summary": logger.get_summary(),
-                    "contents": None
-                }
+    with (
+        storage.get_session(yield_per=10_000),
+        ProgressTicker("Collect compare events", 10_000) as progress
+    ):
+        # Check any dependencies
+        if not meets_dependencies(storage, msg):
+            return {
+                "header": msg["header"],
+                "summary": logger.get_summary(),
+                "contents": None
+            }
 
-            enricher = Enricher(storage, msg)
-            populator = Populator(entity_model, msg)
+        enricher = Enricher(storage, msg)
+        populator = Populator(entity_model, msg)
 
-            # If there are no records in the database all data are ADD events
-            initial_add = not storage.has_any_entity()
-            if initial_add:
-                logger.info("Initial load of new collection detected")
-                # Write ADD events directly, without using a temporary table
-                contents_writer = ContentsWriter()
-                contents_writer.open()
-                # Pass a None confirms_writer because only ADD events are written
-                collector = EventCollector(contents_writer, confirms_writer=None, version=entity_model['version'])
-                collect = collector.collect_initial_add
-            else:
-                # Collect entities in a temporary table
-                collector = EntityCollector(storage)
-                collect = collector.collect
-                tmp_table_name = collector.tmp_table_name
+        # If there are no records in the database all data are ADD events
+        initial_add = not storage.has_any_entity()
+        if initial_add:
+            logger.info("Initial load of new collection detected")
+            # Write ADD events directly, without using a temporary table
+            contents_writer = ContentsWriter()
+            contents_writer.open()
+            # Pass a None confirms_writer because only ADD events are written
+            collector = EventCollector(contents_writer, confirms_writer=None, version=entity_model['version'])
+            collect = collector.collect_initial_add
+        else:
+            # Collect entities in a temporary table
+            collector = EntityCollector(storage)
+            collect = collector.collect
 
-            for entity in msg["contents"]:
-                progress.tick()
-                stats.collect(entity)
-                enricher.enrich(entity)
-                populator.populate(entity)
-                collect(entity)
+        for entity in msg["contents"]:
+            progress.tick()
+            stats.collect(entity)
+            enricher.enrich(entity)
+            populator.populate(entity)
+            collect(entity)
 
-            collector.close()
+        collector.close()
 
-    if initial_add:
-        filename = contents_writer.filename
-        confirms = None
-        contents_writer.close()
-    else:
-        # Compare entities from temporary table
-        with storage.get_session():
-            diff = storage.compare_temporary_data(tmp_table_name, mode)
+        if initial_add:
+            filename = contents_writer.filename
+            confirms = None
+            contents_writer.close()
+        else:
+            diff = storage.compare_temporary_data(mode)
             filename, confirms = _process_compare_results(storage, entity_model, diff, stats)
+
+        # closing session here, removing temporary table
 
     # Build result message
     results = stats.results()

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -19,7 +19,7 @@ from typing import Union, Iterator, Iterable
 from sqlalchemy import (
     create_engine, Table, update, exc as sa_exc, select, column, String, values, Column, text
 )
-from sqlalchemy.engine import Row, Connection
+from sqlalchemy.engine import Row
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import OperationalError, MultipleResultsFound
 from sqlalchemy.ext.automap import automap_base
@@ -329,8 +329,8 @@ WHERE
     def create_temporary_table(self):
         """
         Create a new temporary table based on the current table for a collection.
-
-        Message data is inserted to be compared with the current state
+        Add table to current metadata stored in `base`.
+        The table will be dropped when the connection is released.
         """
         columns: list[Column] = [
             get_column(FIELD.TID, self.fields[FIELD.TID]),

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -441,9 +441,11 @@ WHERE
             self.session.flush()
         finally:
             if invalidate:
-                self.session.invalidate()  # release connection to database
-            else:
-                self.session.close()  # release connection to pool
+                # release connection to database
+                # session.invalidate() does not drop temp tables, bind.invalidate() does
+                self.session.bind.invalidate()
+
+            self.session.close()
             self.session = None
 
     @with_session

--- a/src/tests/compare/test_entity_collector.py
+++ b/src/tests/compare/test_entity_collector.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from gobupload.compare.entity_collector import EntityCollector
+from gobupload.storage.handler import GOBStorageHandler
+
+
+class TestEntityCollector(TestCase):
+
+    def setUp(self):
+        self.storage = MagicMock(spec=GOBStorageHandler)
+        self.collector = EntityCollector(self.storage)
+        self.collector._clear = MagicMock()
+
+    def test_init(self):
+        assert self.collector.storage == self.storage
+        assert self.collector._entities == []
+        self.storage.create_temporary_table.assert_called()
+
+    def test_collect(self):
+        entity = {"any": "value"}
+        self.collector.collect(entity)
+
+        assert self.collector._entities == [entity]
+        self.storage.write_temporary_entities.assert_not_called()
+
+        self.collector.CHUNKSIZE = 1
+        self.collector.collect(entity)
+
+        assert self.collector._entities == [entity] * 2
+        self.storage.write_temporary_entities.assert_called_with(self.collector._entities)
+        self.collector._clear.assert_called()
+
+    def test_close(self):
+        self.collector.close()
+
+        # _entities empty -> write not called
+        self.storage.write_temporary_entities.assert_not_called()
+        self.storage.analyze_temporary_table.assert_called()
+
+        self.collector._entities = [1, 2, 3, 4]
+        self.collector.close()
+        self.storage.write_temporary_entities.assert_called_with([1, 2, 3, 4])
+        self.storage.analyze_temporary_table.assert_called()

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -1,9 +1,10 @@
 import datetime
 import unittest
 from decimal import Decimal
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, MagicMock, patch, ANY
 
 from sqlalchemy import Integer, DateTime, String, JSON
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import declarative_base
 
 from gobcore.events.import_message import ImportMessage
@@ -63,6 +64,7 @@ class MockMeta:
 
 class TestStorageHandler(unittest.TestCase):
 
+    @patch("gobupload.storage.handler.utils.random_string", MagicMock(return_value="xyz"))
     @patch("gobupload.storage.handler.automap_base", MagicMock())
     @patch('gobupload.storage.handler.create_engine', MagicMock())
     def setUp(self):
@@ -345,52 +347,72 @@ WHERE
         ])
         self.storage._drop_indexes.assert_called_once()
 
-    def test_create_temporary_table(self):
-        expected_table = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}_tmp'
+    @patch("gobupload.storage.handler.Table")
+    def test_create_temporary_table(self, mock_table):
+        mock_session = MagicMock(spec=StreamSession)
+        mock_session.bind = MagicMock(spec=Connection)
+        self.storage.session = mock_session
 
         self.storage.create_temporary_table()
 
-        for entity in self.msg["contents"]:
-            self.storage.write_temporary_entity(entity)
+        mock_table.assert_called_with(
+            "meetbouten_meetbouten_xyz",
+            self.storage.base.metadata,
+            *[ANY] * 4,  # columns
+            implicit_returning=False,
+            prefixes=["TEMPORARY"]
+        )
+        mock_table.return_value.create.assert_called_with(bind=mock_session.bind)
 
-        # And the engine has been called to fill the temporary table
-        self.storage.engine.execute.assert_called()
+    def test_write_temporary_entities(self):
+        mock_session = MagicMock(spec=StreamSession)
+        mock_session.stream_execute.return_value = [{"any": "value"}]
+        self.storage.session = mock_session
 
-    def test_create_temporary_table_exists(self):
-        expected_table = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}_tmp'
+        entities = [{"_tid": "1", "_hash": "any", "_id": "any id"}]
+        self.storage.write_temporary_entities(entities)
 
-        mock_table = MagicMock()
-
-        # Make sure the test table already exists
-        self.storage.base.metadata.tables = {expected_table: mock_table}
-        expected_table = self.storage.create_temporary_table()
-
-        # Assert the drop function is called
-        self.storage.engine.execute.assert_any_call(f"DROP TABLE IF EXISTS {expected_table}")
-
-        for entity in self.msg["contents"]:
-            self.storage.write_temporary_entity(entity)
-
-        # And the engine has been called to fill the temporary table
-        self.storage.engine.execute.assert_called()
+        expected = [{
+            "_tid": "1",
+            "_source": "any source",
+            "_hash": "any",
+            "_original_value": {"_tid": "1", "_hash": "any", "_id": "any id"}
+        }]
+        mock_session.execute.assert_called_with(
+            self.storage.base.metadata.tables.__getitem__.return_value.insert.return_value,
+            expected
+        )
 
     def test_compare_temporary_data(self):
+        mock_session = MagicMock(spec=StreamSession)
+        mock_session.stream_execute.return_value = [{"any": "value"}]
+        self.storage.session = mock_session
+
         current = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}'
-        temporary = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}_tmp'
+        temporary = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}_xyz'
+        query = queries.get_comparison_query("any source", current, temporary, ["_tid"])
 
-        fields = ['_tid']
-        query = queries.get_comparison_query('any source', current, temporary, fields)
+        diff = self.storage.compare_temporary_data()
+        result = list(diff)
 
-        diff = self.storage.compare_temporary_data(temporary)
-        results = [result for result in diff]
+        assert result == [{"any": "value"}]
+        mock_session.stream_execute.assert_called_with(query)
 
-        self.storage.engine.execution_options.assert_called_with(stream_results=True)
+    @patch("gobupload.storage.handler.text")
+    def test_analyze_temporary_table(self, mock_text):
+        mock_session = MagicMock(spec=StreamSession)
+        mock_session.bind = MagicMock(spec=Connection)
+        self.storage.session = mock_session
 
-        # Assert the query is performed is deleted
-        self.storage.engine.execution_options().execute.assert_any_call(query)
+        self.storage.analyze_temporary_table()
 
-        # Assert the temporary table is deleted
-        self.storage.engine.execute.assert_any_call(f"DROP TABLE IF EXISTS {temporary}")
+        mock_session.bind.execution_options.has_calls([
+            call(isolation_level="AUTOCOMMIT"),
+            call(isolation_level=mock_session.bind.default_isolation_level)
+        ])
+
+        mock_text.assert_called_with("VACUUM ANALYZE meetbouten_meetbouten_xyz")
+        mock_session.bind.execute.assert_called_with(mock_text.return_value)
 
     def test_get_query_value(self):
         self.storage.get_query_value('SELECT * FROM test')


### PR DESCRIPTION
Use a postgresql TEMPORARY table for comparing data instead of a regular table.
Benefits:
- Dropped automatically at the end of the session
- Not WAL logged, so should be faster
- no naming collisions, temp table only visible to current session
- no other database sessions can interact with it
