### PR TITLE
Refactor apply_confirm_events (#1020)

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -1,6 +1,8 @@
-import os
 import sys
+from pathlib import Path
 
+from gobcore.events.import_events import CONFIRM, BULKCONFIRM
+from gobcore.exceptions import GOBException
 from gobcore.logging.logger import logger
 from gobcore.message_broker.notifications import EventNotification, add_notification
 from gobcore.message_broker.offline_contents import ContentsReader
@@ -44,7 +46,23 @@ def apply_events(storage: GOBStorageHandler, last_events: set[str], start_after:
                     break  # skips 'else' and executes 'finally' => session rollback + closed
 
 
-def apply_confirm_events(storage, stats, msg):
+def _apply_confirms(storage: GOBStorageHandler, confirms: Path, timestamp: str, stats: UpdateStatistics):
+    with ProgressTicker("Apply CONFIRM events", 50_000) as progress:
+        for event in ContentsReader(confirms).items():
+            if event["event"] not in (CONFIRM.name, BULKCONFIRM.name):
+                raise GOBException(f"Expected 'CONFIRM' or 'BULKCONFIRM' got: {event['event']}")
+
+            # get confirm data: BULKCONFIRM => data.confirms, CONFIRM => [data]
+            confirm_data = event["data"].get("confirms", [event["data"]])
+            confirm_len = len(confirm_data)
+
+            progress.ticks(confirm_len)
+
+            storage.apply_confirms(confirm_data, timestamp=timestamp)
+            stats.add_applied(CONFIRM.name, confirm_len)
+
+
+def apply_confirm_events(storage: GOBStorageHandler, stats: UpdateStatistics, msg: dict):
     """
     Apply confirm events (if present)
 
@@ -56,25 +74,19 @@ def apply_confirm_events(storage, stats, msg):
     :param msg:
     :return:
     """
-    confirms = msg.get('confirms')
-    # SKIP confirms for relations
-    catalogue = msg['header'].get('catalogue', "")
-    if confirms and catalogue != 'rel':
-        reader = ContentsReader(confirms)
-        with ProgressTicker("Apply CONFIRM events", 10000) as progress:
-            for event in reader.items():
-                progress.tick()
-                action = event['event']
-                assert action in ['CONFIRM', 'BULKCONFIRM']
-                # get confirm data: BULKCONFIRM => data.confirms, CONFIRM => [data]
-                confirm_data = event['data'].get('confirms', [event['data']])
-                storage.apply_confirms(confirm_data, msg['header']['timestamp'])
-                stats.add_applied('CONFIRM', len(confirm_data))
-        reader.close()
-    if confirms:
-        # Remove file after it has been handled (or skipped)
-        os.remove(confirms)
-        del msg['confirms']
+    if not msg.get("confirms"):
+        return
+
+    confirms = Path(msg["confirms"])
+    catalogue = msg['header'].get("catalogue", "")
+    timestamp = msg["header"]["timestamp"]
+
+    try:
+        if catalogue != "rel":
+            _apply_confirms(storage, confirms, timestamp=timestamp, stats=stats)
+    finally:
+        confirms.unlink(missing_ok=True)
+        del msg["confirms"]
 
 
 def _should_analyze(stats):

--- a/src/gobupload/compare/event_collector.py
+++ b/src/gobupload/compare/event_collector.py
@@ -9,8 +9,8 @@ from gobcore.model.metadata import FIELD
 
 class EventCollector:
 
-    MAX_BULK = 10000          # Max number of events of same type in one bulk event
-    BULK_TYPES = ["CONFIRM"]  # Only CONFIRM events are grouped in bulk events
+    MAX_BULK = 100_000          # Max number of events of same type in one bulk event
+    BULK_TYPES = ["CONFIRM"]    # Only CONFIRM events are grouped in bulk events
 
     def __init__(self, contents_writer, confirms_writer, version):
         """

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
 alembic~=1.9.3
 more-itertools~=8.8.0
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.3.3#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.4.0#egg=gobcore

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -56,6 +56,17 @@ class MockEvents(Base):
     tid = sa.Column(String)
 
 
+class MockMeetbouten(Base):
+    __tablename__ = "meetbouten_meetbouten"
+
+    eventid = sa.Column(Integer, primary_key=True)
+    timestamp = sa.Column(DateTime)
+    catalogue = sa.Column(String)
+    entity = sa.Column(String)
+    _tid = sa.Column(String)
+    _date_confirmed = sa.Column(DateTime)
+
+
 class MockMeta:
     source = "AMSBI"
     catalogue = "meetbouten"
@@ -90,6 +101,7 @@ class TestStorageHandler(unittest.TestCase):
         GOBStorageHandler.engine.begin = lambda: GOBStorageHandler.engine
 
         GOBStorageHandler.base.classes.events = MockEvents
+        GOBStorageHandler.base.classes.meetbouten_meetbouten = MockMeetbouten
 
     @patch("gobupload.storage.handler.automap_base")
     def test_base(self, mock_base):
@@ -518,3 +530,29 @@ WHERE
         mock_execute.reset_mock()
         obj.stream_execute("query", extra=5, execution_options={"yield_per": 2000})
         mock_execute.assert_called_with("query", execution_options={"yield_per": 2000}, extra=5)
+
+        # test we don't overwrite yield_per when set on the connection
+        mock_execute.reset_mock()
+        obj.bind = MagicMock(spec=Connection)
+        obj.bind.get_execution_options.return_value = {"yield_per": 1000}
+        obj.stream_execute("query")
+        mock_execute.assert_called_with("query")
+
+
+    @patch("gobupload.storage.handler.GOBStorageHandler.execute")
+    def test_apply_confirms(self, mock_execute):
+        confirms = [{"_tid": "confirm1"}, {"_tid": "confirm2"}]
+        timestamp = "any ts"
+
+        self.storage.apply_confirms(confirms, timestamp)
+
+        query = mock_execute.call_args[0][0]
+        query = str(query.compile(compile_kwargs={"literal_binds": True}))
+
+        expected = (
+            "UPDATE meetbouten_meetbouten "
+            "SET _date_confirmed='any ts' "
+            "FROM (VALUES ('confirm1'), ('confirm2')) AS tids (_tid) "
+            "WHERE meetbouten_meetbouten._tid = tids._tid"
+        )
+        assert query == expected

--- a/src/tests/update/test_main.py
+++ b/src/tests/update/test_main.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 
 from gobupload.update.main import is_corrupted
 


### PR DESCRIPTION
* Refactor apply_confirm_events

* Return early on empty confirms from message

* Fix: only set default value for `yield_per` if not set on connection yet

* Update Core

* Add tests for not overwriting yield_per from connection execution options