### PR TITLE
Remove `contents` from return message

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -152,10 +152,13 @@ def apply(msg):
         stats.log()
         logger.info(f"Apply events {model} completed", {'data': results})
 
-    msg['summary'] = logger.get_summary()
+    message = {
+        "header": msg["header"],
+        "summary": logger.get_summary(),
+    }
 
     # Add events notification telling what types of event have been applied
     if not msg['header'].get('suppress_notifications', False):
-        add_notification(msg, EventNotification(stats.applied, [before, after]))
+        add_notification(message, EventNotification(stats.applied, [before, after]))
 
-    return msg
+    return message

--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -130,7 +130,6 @@ def check_relation(msg: dict):
     return {
         "header": msg["header"],
         "summary": logger.get_summary(),
-        "contents": None
     }
 
 

--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -117,7 +117,6 @@ def full_update(msg):
     message = {
         "header": msg["header"],
         "summary": results,
-        "contents": None,
         "confirms": msg.get('confirms')
     }
     return message


### PR DESCRIPTION
This caused the next task to pick up an empty offloaded file