### PR TITLE
Assign connection with execution_options

### DIFF
--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -436,9 +436,8 @@ WHERE
             e.g. 'compile_cache' and 'yield_per'
         """
         connection = self.engine.connect()
-        if execution_options:
-            connection.execution_options(**execution_options)
-
+        # sqlalchemy < 2.0: connection.execution_options returns a copy, not inplace
+        connection = connection.execution_options(**execution_options) if execution_options else connection
         self.session = self.Session(bind=connection)
 
         try:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
 alembic~=1.9.4
 more-itertools~=9.0.0
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.4.1#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.4.2#egg=gobcore

--- a/src/tests/storage/test_storage.py
+++ b/src/tests/storage/test_storage.py
@@ -95,18 +95,20 @@ class TestContextManager(unittest.TestCase):
         handler.GOBStorageHandler.Session = mock_session
         storage = handler.GOBStorageHandler(fixtures.random_string())
 
-        mock_conn = MagicMock()
+        mock_conn = MagicMock(spec=Connection)
         storage.engine.connect.return_value = mock_conn
 
         mock_session_instance = MagicMock()
         mock_session.return_value = mock_session_instance
 
         with storage.get_session(compile_cache=None) as session:
-            self.assertEqual(session, mock_session_instance)
-            self.assertEqual(storage.session, mock_session_instance)
+            assert session == mock_session_instance
+            assert storage.session == mock_session_instance
 
         mock_conn.execution_options.assert_called_with(compile_cache=None)
-        mock_session.assert_called_with(bind=mock_conn)
+
+        # assert we call session with connection including execution options (copy)
+        mock_session.assert_called_with(bind=mock_conn.execution_options.return_value)
 
     def test_session_context_invalidate(self):
         mock_session = MagicMock(spec=StreamSession)


### PR DESCRIPTION
Does not operate inplace for sqlalchemy < 2.0