### PR TITLE
Remove execution_options from get_session

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -133,7 +133,7 @@ def apply(msg):
             apply_confirm_events(storage, stats, msg)
         else:
             logger.info(f"Start application of unhandled {model} events")
-            with storage.get_session(compile_cache=None):
+            with storage.get_session():
                 last_events = set(storage.get_current_ids(exclude_deleted=False))
 
             apply_events(storage, last_events, entity_max_eventid, stats)

--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -70,7 +70,7 @@ def compare(msg):
 
     stats = CompareStatistics()
 
-    with storage.get_session(invalidate=True, yield_per=10_000):
+    with storage.get_session(invalidate=True):
         # Check any dependencies
         if not meets_dependencies(storage, msg):
             return {

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -412,7 +412,7 @@ WHERE
         result = list(diff)
 
         assert result == [{"any": "value"}]
-        mock_session.stream_execute.assert_called_with(query)
+        mock_session.stream_execute.assert_called_with(query, execution_options={"yield_per": 10_000})
 
     @patch("gobupload.storage.handler.text")
     def test_analyze_temporary_table(self, mock_text):
@@ -531,13 +531,6 @@ WHERE
         mock_execute.reset_mock()
         obj.stream_execute("query", extra=5, execution_options={"yield_per": 2000})
         mock_execute.assert_called_with("query", execution_options={"yield_per": 2000}, extra=5)
-
-        # test we don't overwrite yield_per when set on the connection
-        mock_execute.reset_mock()
-        obj.bind = MagicMock(spec=Connection)
-        obj.bind.get_execution_options.return_value = immutabledict({"yield_per": 1000})
-        obj.stream_execute("query")
-        mock_execute.assert_called_with("query")
 
     @patch("gobupload.storage.handler.GOBStorageHandler.execute")
     def test_apply_confirms(self, mock_execute):

--- a/src/tests/storage/test_storage.py
+++ b/src/tests/storage/test_storage.py
@@ -90,26 +90,6 @@ class TestContextManager(unittest.TestCase):
         mock_session_instance.close.assert_called()
         mock_logger.error.assert_called_with("ConnectionError('any')")
 
-    def test_session_context_execution_options(self):
-        mock_session = MagicMock()
-        handler.GOBStorageHandler.Session = mock_session
-        storage = handler.GOBStorageHandler(fixtures.random_string())
-
-        mock_conn = MagicMock(spec=Connection)
-        storage.engine.connect.return_value = mock_conn
-
-        mock_session_instance = MagicMock()
-        mock_session.return_value = mock_session_instance
-
-        with storage.get_session(compile_cache=None) as session:
-            assert session == mock_session_instance
-            assert storage.session == mock_session_instance
-
-        mock_conn.execution_options.assert_called_with(compile_cache=None)
-
-        # assert we call session with connection including execution options (copy)
-        mock_session.assert_called_with(bind=mock_conn.execution_options.return_value)
-
     def test_session_context_invalidate(self):
         mock_session = MagicMock(spec=StreamSession)
         handler.GOBStorageHandler.Session = mock_session


### PR DESCRIPTION
Setting this on the connection leads to (vague) exceptions during CREATE TEMPORARY TABLE.
Instead, use the options during executing the query. ie: `session.execute(query, execution_options={..})`
passes end-2-end test

error:
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near \"CREATE\""
LINE 2: CREATE TEMPORARY TABLE nap_peilmerken_tmp ("