### PR TITLE
Use psql TEMPORARY table in relate

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -82,8 +82,7 @@ def apply_confirm_events(storage: GOBStorageHandler, stats: UpdateStatistics, ms
     timestamp = msg["header"]["timestamp"]
 
     try:
-        if catalogue != "rel":
-            _apply_confirms(storage, confirms, timestamp=timestamp, stats=stats)
+        _apply_confirms(storage, confirms, timestamp=timestamp, stats=stats)
     finally:
         confirms.unlink(missing_ok=True)
         del msg["confirms"]

--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -78,7 +78,6 @@ def apply_confirm_events(storage: GOBStorageHandler, stats: UpdateStatistics, ms
         return
 
     confirms = Path(msg["confirms"])
-    catalogue = msg['header'].get("catalogue", "")
     timestamp = msg["header"]["timestamp"]
 
     try:

--- a/src/gobupload/relate/__init__.py
+++ b/src/gobupload/relate/__init__.py
@@ -314,13 +314,20 @@ def process_relate(msg: dict):
     if full_update:
         logger.info("Full relate requested")
 
-    with Relater(header[CATALOG_KEY], header[COLLECTION_KEY], header[ATTRIBUTE_KEY]) as updater:
-        filename, confirms = updater.update(full_update)
+    storage = GOBStorageHandler()
+    filename = None
+
+    with (
+        storage.get_session(invalidate=True) as session,
+        Relater(session, header[CATALOG_KEY], header[COLLECTION_KEY], header[ATTRIBUTE_KEY]) as updater
+    ):
+        filename = updater.update(full_update)
 
     logger.info("Relate table completed")
 
     relation_name = get_relation_name(
-        gob_model, header[CATALOG_KEY], header[COLLECTION_KEY], header[ATTRIBUTE_KEY])
+        gob_model, header[CATALOG_KEY], header[COLLECTION_KEY], header[ATTRIBUTE_KEY]
+    )
 
     result_msg = {
         "header": {
@@ -335,7 +342,6 @@ def process_relate(msg: dict):
         },
         "summary": logger.get_summary(),
         "contents_ref": filename,
-        "confirms": confirms,
     }
 
     return result_msg

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -162,13 +162,6 @@ class TestApply(TestCase):
         apply_confirm_events(MagicMock(), MagicMock(), {'header': {}, "confirms": []})
         mock_apply.assert_not_called()
 
-    @patch("gobupload.apply.main._apply_confirms")
-    def test_apply_confirms_rel_cat(self, mock_apply, _):
-        msg = {'header': {"catalogue": "rel", "timestamp": "any ts"}, "confirms": "any"}
-        apply_confirm_events(MagicMock(), MagicMock(), msg)
-        mock_apply.assert_not_called()
-        assert "confirms" not in msg
-
     @patch('gobupload.apply.main.add_notification', MagicMock())
     @patch('gobupload.apply.main.logger', MagicMock())
     @patch('gobupload.apply.main.get_event_ids', lambda s: (2, 1))


### PR DESCRIPTION
- Stop generating CONFIRM events during relate
- Also remove exemption from apply for `rel`
- ANALYZE temporary tables after inserting
- simplify statements, remove StopIteration