### PR TITLE
Fix compare chunked iter

### DIFF
--- a/src/gobupload/compare/main.py
+++ b/src/gobupload/compare/main.py
@@ -5,7 +5,6 @@ Derive Add, Change, Delete and Confirm events by comparing a full set of new dat
 Todo: Event, action and mutation are used for the same subject. Use one name to improve maintainability.
 """
 from typing import Iterator, Callable, Any
-from more_itertools import chunked
 from sqlalchemy.engine import Row
 
 from gobcore.enum import ImportMode
@@ -194,7 +193,7 @@ def _process_compare_result_row(
 
 
 def _process_compare_results(
-        storage: GOBStorageHandler, model: dict, results: Iterator[Row], stats: CompareStatistics
+        storage: GOBStorageHandler, model: dict, results: Iterator[list[Row]], stats: CompareStatistics
 ) -> tuple[str, str]:
     """Process the results of the in database compare.
 
@@ -212,7 +211,7 @@ def _process_compare_results(
         ContentsWriter() as confirms_writer,
         EventCollector(contents_writer, confirms_writer, version) as event_collector
     ):
-        for chunk in chunked(results, 10_000):
+        for chunk in results:
             modify_cur_entities = _get_modify_current_entities(storage, chunk)
 
             for row in chunk:

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -393,7 +393,7 @@ WHERE
             fields=[FIELD.TID],
             mode=mode
         )
-        yield from self.session.stream_execute(query).partitions(size=25_000)
+        return self.session.stream_execute(query).partitions(size=25_000)
 
     @with_session
     def analyze_temporary_table(self):

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -402,7 +402,7 @@ WHERE
 
         # Temporary switch to database AUTOCOMMIT, reset after VACUUM
         conn.execution_options(isolation_level="AUTOCOMMIT")
-        conn.execute(text(f"VACUUM ANALYZE {self.tablename_temp}"))
+        conn.execute(text(f"ANALYZE {self.tablename_temp}"))
         conn.execution_options(isolation_level=conn.default_isolation_level)
 
     @property

--- a/src/tests/compare/test_compare.py
+++ b/src/tests/compare/test_compare.py
@@ -88,7 +88,7 @@ class TestCompare(TestCase):
             _hash = "1234567890"
             _entity_tid = 2
 
-        self.mock_storage.compare_temporary_data.return_value = [Row]
+        self.mock_storage.compare_temporary_data.return_value = yield [Row]
         message = fixtures.get_message_fixture()
 
         with self.assertRaises(GOBException):
@@ -110,7 +110,7 @@ class TestCompare(TestCase):
             _hash = "1234567890"
             _entity_tid = 2
 
-        self.mock_storage.compare_temporary_data.return_value = [Row]
+        self.mock_storage.compare_temporary_data.return_value = yield [Row]
         message = fixtures.get_message_fixture()
 
         result = compare(message)
@@ -139,7 +139,7 @@ class TestCompare(TestCase):
             _last_event = 1
             _hash = "1234567890"
 
-        self.mock_storage.compare_temporary_data.return_value = [Row]
+        self.mock_storage.compare_temporary_data.return_value = yield [Row]
 
         result = compare(message)
 
@@ -168,7 +168,7 @@ class TestCompare(TestCase):
             _last_event = 1
             _hash = "1234567890"
 
-        self.mock_storage.compare_temporary_data.return_value = [Row]
+        self.mock_storage.compare_temporary_data.return_value = yield [Row]
 
         result = compare(message)
 
@@ -192,7 +192,7 @@ class TestCompare(TestCase):
             _last_event = 1
             _hash = "1234567890"
 
-        self.mock_storage.compare_temporary_data.return_value = [Row]
+        self.mock_storage.compare_temporary_data.return_value = yield [Row]
         message = fixtures.get_message_fixture()
 
         result = compare(message)
@@ -218,7 +218,7 @@ class TestCompare(TestCase):
             _last_event = 1
             _hash = "1234567890"
 
-        self.mock_storage.compare_temporary_data.return_value = [Row] * 2
+        self.mock_storage.compare_temporary_data.return_value = yield [Row] * 2
         message = fixtures.get_message_fixture()
 
         result = compare(message)
@@ -276,7 +276,7 @@ class TestCompare(TestCase):
             _last_event = 1
             _hash = "1234567890"
 
-        self.mock_storage.compare_temporary_data.return_value = [Row]
+        self.mock_storage.compare_temporary_data.return_value = yield [Row]
 
         result = compare(message)
 

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -402,7 +402,7 @@ WHERE
     def test_compare_temporary_data(self):
         mock_session = MagicMock(spec=StreamSession)
         row = type("Row", (object, ), {"any": "value"})
-        mock_session.stream_execute.return_value.partitions.return_value = [row]
+        mock_session.stream_execute.return_value.partitions.return_value = yield [row]
         self.storage.session = mock_session
 
         current = f'{self.msg["header"]["catalogue"]}_{self.msg["header"]["entity"]}'
@@ -411,7 +411,8 @@ WHERE
 
         diff = self.storage.compare_temporary_data()
 
-        assert next(diff) == row
+        for result in diff:
+            assert result == [row]
         mock_session.stream_execute.assert_called_with(query)
         mock_session.stream_execute.return_value.partitions.assert_called_once()
 

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -428,7 +428,7 @@ WHERE
             call(isolation_level=mock_session.bind.default_isolation_level)
         ])
 
-        mock_text.assert_called_with("VACUUM ANALYZE meetbouten_meetbouten_tmp")
+        mock_text.assert_called_with("ANALYZE meetbouten_meetbouten_tmp")
         mock_session.bind.execute.assert_called_with(mock_text.return_value)
 
     def test_get_query_value(self):

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -412,7 +412,7 @@ WHERE
         diff = self.storage.compare_temporary_data()
 
         assert next(diff) == row
-        mock_session.stream_execute.assert_called_with(query, execution_options={"yield_per": 10_000})
+        mock_session.stream_execute.assert_called_with(query)
         mock_session.stream_execute.return_value.partitions.assert_called_once()
 
     @patch("gobupload.storage.handler.text")
@@ -520,7 +520,7 @@ WHERE
     @patch("gobupload.storage.handler.SessionORM.execute")
     def test_stream_session(self, mock_execute, mock_scalars):
         obj = StreamSession()
-        default_opts = {"execution_options": {"yield_per": obj.YIELD_PER}}
+        default_opts = {"execution_options": {"stream_results": True, "yield_per": obj.YIELD_PER}}
 
         obj.stream_execute("query", extra=5)
         mock_execute.assert_called_with("query", **default_opts, extra=5)
@@ -530,7 +530,9 @@ WHERE
 
         mock_execute.reset_mock()
         obj.stream_execute("query", extra=5, execution_options={"yield_per": 2000})
-        mock_execute.assert_called_with("query", execution_options={"yield_per": 2000}, extra=5)
+        mock_execute.assert_called_with(
+            "query", execution_options={"yield_per": 2000, "stream_results": True}, extra=5
+        )
 
     @patch("gobupload.storage.handler.GOBStorageHandler.execute")
     def test_apply_confirms(self, mock_execute):


### PR DESCRIPTION
It seems `chunked` consumes every first element from the iterator, instead use sqlalchemy's `partitions`