### PR TITLE
Select temp columns relate

### DIFF
--- a/src/gobupload/relate/update.py
+++ b/src/gobupload/relate/update.py
@@ -122,10 +122,10 @@ class Table:
     def __eq__(self, other: "Table"):
         return self.tablename == other.tablename
 
-    def clone_using_columnar(self, session):
-        logger.info(f"Creating temporary citus table for: {self.tablename}")
+    def clone_using_columnar(self, session: StreamSession, columns: list[str] = None):
+        logger.info(f"Creating temporary citus table {self.tablename}")
         session.execute(f"CREATE TEMPORARY TABLE {self.tablename}_clone USING columnar AS "
-                        f"SELECT * FROM {self.tablename}")
+                        f"SELECT {', '.join(columns) if columns else '*'} FROM {self.tablename}")
         session.execute(f"ANALYZE {self.tablename}_clone")
         return Table(f"{self.tablename}_clone")
 
@@ -181,6 +181,15 @@ class Relater:
         f'rel_{FIELD.HASH}',
     ]
 
+    _tmp_columns = [
+        FIELD.APPLICATION,
+        FIELD.EXPIRATION_DATE,
+        FIELD.SOURCE,
+        FIELD.ID,
+        FIELD.LAST_EVENT,
+        FIELD.DATE_DELETED
+    ]
+
     def __init__(self, session: StreamSession, src_catalog_name: str, src_collection_name: str, src_field_name: str):
         self.session = session
         self.src_catalog_name = src_catalog_name
@@ -189,47 +198,90 @@ class Relater:
 
         self.src_collection = self.model[src_catalog_name]['collections'][src_collection_name]
         self.src_field = self.src_collection['all_fields'].get(src_field_name)
-        src_table_orig = Table(self.model.get_table_name(src_catalog_name, src_collection_name))
-        self.src_table_name = src_table_orig.clone_using_columnar(session).tablename
-
+        self.is_many = self.src_field['type'] == "GOB.ManyReference"
         # Get the destination catalog and collection names
         self.dst_catalog_name, self.dst_collection_name = self.src_field['ref'].split(':')
         self.dst_collection = self.model[self.dst_catalog_name]['collections'][self.dst_collection_name]
-        dst_table_orig = Table(self.model.get_table_name(self.dst_catalog_name, self.dst_collection_name))
-
-        if dst_table_orig == src_table_orig:
-            self.dst_table_name = self.src_table_name
-        else:
-            self.dst_table_name = dst_table_orig.clone_using_columnar(session).tablename
 
         # Check if source or destination has states (volgnummer, begin_geldigheid, eind_geldigheid)
         self.src_has_states = self.model.has_states(self.src_catalog_name, self.src_collection_name)
         self.dst_has_states = self.model.has_states(self.dst_catalog_name, self.dst_collection_name)
 
+        # init table(names)
+        src_table_orig = Table(self.model.get_table_name(self.src_catalog_name, self.src_collection_name))
+        dst_table_orig = Table(self.model.get_table_name(self.dst_catalog_name, self.dst_collection_name))
+        rel_table_orig = Table(
+            "rel_" + get_relation_name(self.model, src_catalog_name, src_collection_name, src_field_name)
+        )
+
+        self.src_table_name = src_table_orig.tablename
+        self.dst_table_name = self.src_table_name if dst_table_orig == src_table_orig else dst_table_orig.tablename
+        self.relation_table = rel_table_orig.tablename
+        self.result_table_name = "_".join([
+            self.src_catalog_name, self.src_collection["abbreviation"], src_field_name, "result"
+        ]).lower()
+
+        # Only include specs that are present in the src table.
+        # If no specs are left this implies that the src table is empty.
+        self.relation_specs = self._get_relation_specs(src_catalog_name, src_collection_name, src_field_name)
+
+        src_table_orig.clone_using_columnar(self.session, self._src_table_columns)
+        if dst_table_orig != src_table_orig:
+            dst_table_orig.clone_using_columnar(self.session, self._dst_table_columns)
+
+        rel_table_orig.clone_using_columnar(self.session, self._rel_table_columns)
+
+    @property
+    def _src_table_columns(self) -> list[str]:
+        """Return columns necessary to relate for temp source table."""
+        return [
+            self.src_field_name,
+            *self._tmp_columns,
+            *{rel["source_attribute"] for rel in self.relation_specs if rel.get("source_attribute")},
+            *([FIELD.SEQNR, FIELD.START_VALIDITY, FIELD.END_VALIDITY] if self.src_has_states else [])
+        ]
+
+    @property
+    def _rel_table_columns(self) -> list[str]:
+        """Return columns necessary to relate for temp current relation table."""
+        return [
+            FIELD.ID,
+            FIELD.LAST_EVENT,
+            FIELD.HASH,
+            FIELD.DATE_DELETED,
+            FIELD.REFERENCE_ID,
+            "src_source",
+            "src_id",
+            "dst_id",
+            "dst_volgnummer",
+            FIELD.EXPIRATION_DATE,
+            FIELD.SOURCE_VALUE,
+            FIELD.START_VALIDITY,
+            FIELD.END_VALIDITY,
+            FIELD.LAST_DST_EVENT,
+            FIELD.LAST_SRC_EVENT,
+        ]
+
+    @property
+    def _dst_table_columns(self) -> list[str]:
+        """Return columns necessary to relate for temp destination table."""
+        return [
+            *self._tmp_columns,
+            *{rel["destination_attribute"] for rel in self.relation_specs if rel.get("destination_attribute")},
+            *([FIELD.SEQNR, FIELD.START_VALIDITY, FIELD.END_VALIDITY] if self.dst_has_states else [])
+        ]
+
+    def _get_relation_specs(self, catalog: str, collection: str, field: str) -> list[dict]:
         # Copy relation specs and set default for multiple_allowed. Filter out specs that are not present in src.
-        relation_specs = [{
-            **spec,
-            'multiple_allowed': spec.get('multiple_allowed', False)
-        } for spec in self.sources.get_field_relations(src_catalog_name, src_collection_name, src_field_name)]
+        fieldrelations = self.sources.get_field_relations(catalog, collection, field)
+        relation_specs = [spec | {"multiple_allowed": spec.get("multiple_allowed", False)} for spec in fieldrelations]
 
         if not relation_specs:
             raise RelateException(
-                "Missing relation specification for "
-                f"{src_catalog_name} {src_collection_name} {src_field_name} "
-                "(sources.get_field_relations)")
-        src_applications = self._get_applications_in_src()
+                f"Missing relation specification for {catalog} {collection} {field} (sources.get_field_relations)"
+            )
 
-        # Only include specs that are present in the src table. If no specs are left this implies that the src table is
-        # empty.
-        self.relation_specs = [spec for spec in relation_specs if spec['source'] in src_applications]
-
-        self.is_many = self.src_field['type'] == "GOB.ManyReference"
-        self.relation_table = Table("rel_" + get_relation_name(self.model, src_catalog_name, src_collection_name,
-                                                               src_field_name)).clone_using_columnar(session).tablename
-
-        self.result_table_name = "_".join([
-            self.src_catalog_name, self.src_collection['abbreviation'], src_field_name, "result"
-        ]).lower()
+        return [spec for spec in relation_specs if spec["source"] in self._get_applications_in_src()]
 
     def __enter__(self):
         self._create_tmp_result_table()

--- a/src/tests/relate/test_update.py
+++ b/src/tests/relate/test_update.py
@@ -270,6 +270,31 @@ class TestRelaterInit(TestCase):
         relater = Relater(MagicMock(), "src_catalog_name", "src_many_collection_name", "src_field_name")
         assert relater.is_many is True
 
+    def test_init_temp_tables(self):
+        relater = self.relater()
+        mock_exec = relater.session.execute
+
+        mock_exec.assert_any_call(
+            "CREATE TEMPORARY TABLE src_catalog_name_src_collection_name_table_clone USING columnar AS "
+            "SELECT src_field_name, _application, _expiration_date, _source, _id, _last_event, _date_deleted, "
+            "volgnummer, begin_geldigheid, eind_geldigheid "
+            "FROM src_catalog_name_src_collection_name_table"
+        )
+
+        mock_exec.assert_any_call(
+            "CREATE TEMPORARY TABLE dst_catalog_name_dst_collection_name_table_clone USING columnar AS "
+            "SELECT _application, _expiration_date, _source, _id, _last_event, _date_deleted "
+            "FROM dst_catalog_name_dst_collection_name_table"
+        )
+
+        mock_exec.assert_any_call(
+            "CREATE TEMPORARY TABLE rel_src_catalog_name_src_collection_name_src_field_name_clone USING columnar AS "
+            "SELECT _id, _last_event, _hash, _date_deleted, id, src_source, src_id, src_volgnummer, dst_id, "
+            "dst_volgnummer, _expiration_date, bronwaarde, begin_geldigheid, eind_geldigheid, _last_dst_event, "
+            "_last_src_event "
+            "FROM rel_src_catalog_name_src_collection_name_src_field_name"
+        )
+
 
 @patch("gobupload.relate.update.logger", MagicMock())
 @patch("gobupload.relate.update.Relater.model", MockModel())


### PR DESCRIPTION
- Copy the necessary columns for the relate process to temporary tables. 
- In case of (very) wide src/dst tables this prevents copying data we don't need during relate.
- Moved initialisation of temp tables to seperate method