### PR TITLE
Update core and add migrations for last BRK2 schemas (#1136)

### DIFF
--- a/src/alembic/versions/7c4e8e803d5b_update_brk2_schemas.py
+++ b/src/alembic/versions/7c4e8e803d5b_update_brk2_schemas.py
@@ -1,0 +1,26 @@
+"""update brk2 schemas
+
+Revision ID: 7c4e8e803d5b
+Revises: 98c6dfc4986e
+Create Date: 2023-07-07 07:22:43.410094
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '7c4e8e803d5b'
+down_revision = '98c6dfc4986e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP VIEW IF EXISTS legacy.brk2_stukdelen")
+    op.add_column('brk2_stukdelen', sa.Column('is_bron_voor_brk_erfpachtcanon', postgresql.JSONB(astext_type=sa.Text()), autoincrement=False, nullable=True))
+
+
+def downgrade():
+    op.drop_column('brk2_stukdelen', 'is_bron_voor_brk_erfpachtcanon')

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
 alembic~=1.11.1
 more-itertools~=9.1.0
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.11.2#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.12.0#egg=gobcore


### PR DESCRIPTION
* Update core and add migrations for last BRK2 schemas

* Set core version to v2.12.0

* Drop legacy view if exists