### PR TITLE
Batch updates + fix alembic connection string

### DIFF
--- a/src/alembic/env.py
+++ b/src/alembic/env.py
@@ -51,13 +51,14 @@ def run_migrations_online():
     """
     # Register database URL
     ini_section = config.get_section(config.config_ini_section)
-    ini_section['sqlalchemy.url'] = URL(**GOB_DB)
+    ini_section['sqlalchemy.url'] = URL.create(**GOB_DB)
 
     # Connect to database
     connectable = engine_from_config(
         ini_section,
         prefix='sqlalchemy.',
-        poolclass=pool.NullPool)
+        poolclass=pool.NullPool
+    )
 
     with connectable.connect() as connection:
         context.configure(

--- a/src/gobupload/config.py
+++ b/src/gobupload/config.py
@@ -5,10 +5,10 @@ FULL_UPLOAD = "full"
 DEBUG = True if os.getenv("DEBUG") else False
 
 GOB_DB = {
-    'drivername': 'postgresql',
-    'username': os.getenv("DATABASE_USER", "gob"),
-    'database': os.getenv("DATABASE_NAME", "gob"),
-    'password': os.getenv("DATABASE_PASSWORD", "insecure"),
-    'host': os.getenv("DATABASE_HOST_OVERRIDE", "localhost"),
-    'port': os.getenv("DATABASE_PORT_OVERRIDE", 5406),
+    "drivername": "postgresql",
+    "username": os.getenv("DATABASE_USER", "gob"),
+    "database": os.getenv("DATABASE_NAME", "gob"),
+    "password": os.getenv("DATABASE_PASSWORD", "insecure"),
+    "host": os.getenv("DATABASE_HOST_OVERRIDE", "localhost"),
+    "port": os.getenv("DATABASE_PORT_OVERRIDE", 5406),
 }

--- a/src/gobupload/utils.py
+++ b/src/gobupload/utils.py
@@ -1,25 +1,5 @@
-import gc
 import string
 import random
-
-
-class ActiveGarbageCollection:
-
-    def __init__(self, title):
-        assert gc.isenabled(), "Garbage collection should be enabled"
-        self.title = title
-
-    def __enter__(self):
-        self._collect("start")
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._collect("completion")
-
-    def _collect(self, step):
-        n = gc.collect()
-        if n > 0:
-            print(f"{self.title}: freed {n} unreachable objects on {step}")
 
 
 def is_corrupted(entity_max_eventid, last_eventid):

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -3,7 +3,7 @@ import unittest
 from decimal import Decimal
 from unittest.mock import call, MagicMock, patch, ANY, PropertyMock
 
-from sqlalchemy import Integer, DateTime, String, JSON, text, Engine, select
+from sqlalchemy import Integer, DateTime, String, JSON, Engine, select
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import declarative_base
 
@@ -11,6 +11,7 @@ from gobcore.events.import_message import ImportMessage
 from gobcore.exceptions import GOBException
 
 import sqlalchemy as sa
+from sqlalchemy.util.langhelpers import symbol
 
 from gobupload.compare.populate import Populator
 from gobupload.storage import queries
@@ -70,6 +71,15 @@ class MockMeta:
     source = "AMSBI"
     catalogue = "meetbouten"
     entity = "meetbouten"
+
+
+class TestCreateEngine(unittest.TestCase):
+
+    def test_create_engine(self):
+        assert GOBStorageHandler.engine.dialect.executemany_batch_page_size == 10_000
+        assert GOBStorageHandler.engine.dialect.executemany_mode == symbol("EXECUTEMANY_VALUES_PLUS_BATCH")
+        assert GOBStorageHandler.engine.dialect.use_insertmanyvalues is False
+        assert GOBStorageHandler.engine.driver == "psycopg2"
 
 
 class TestStorageHandler(unittest.TestCase):

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -1,25 +1,11 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 
 from string import ascii_lowercase
 
-from gobupload.utils import ActiveGarbageCollection, random_string
+from gobupload.utils import random_string
 
 
 class TestUpdate(TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    @patch('gobupload.utils.gc')
-    def testGarbageCollection(self, mocked_gc):
-        mocked_gc.collect = MagicMock(return_value=1)
-        with ActiveGarbageCollection("any title") as agc:
-            self.assertEqual(agc.title, "any title")
-            self.assertEqual(mocked_gc.collect.call_count, 1)
-        self.assertEqual(mocked_gc.collect.call_count, 2)
 
     def test_random_string(self):
         self.assertEqual(6, len(random_string(6)))


### PR DESCRIPTION
~~needs rebase https://github.com/Amsterdam/GOB-Upload/pull/1144~~

 - tweaking the`executemany` engine parameters did the trick
SQLAlchemy will group as much as possible in 1 UPDATE statement. 
The INSERTS were already grouped in batches of 10_000, disable the `insertmanyvalues` feature though. We don't need to use `RETURNING`.

- Fix: use URL.create in constructing connection string (required for sqlalchemy v2)
- Remove unused GargabeCollector class