### PR TITLE
Misc storage handler fixes

### DIFF
--- a/src/gobupload/apply/main.py
+++ b/src/gobupload/apply/main.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from typing import Sequence
 
 from sqlalchemy.engine import Row
 
@@ -97,7 +98,7 @@ def _should_analyze(stats):
         sum([value['absolute'] for value in applied_stats.values()]) > 0
 
 
-def _get_source_catalog_entity_combinations(msg) -> list[Row]:
+def _get_source_catalog_entity_combinations(msg) -> Sequence[Row]:
     header = msg["header"]
     storage = GOBStorageHandler(only=[GOBStorageHandler.EVENTS_TABLE])
 
@@ -108,9 +109,7 @@ def _get_source_catalog_entity_combinations(msg) -> list[Row]:
         # we should not query event table without filters
         raise GOBException(f"No catalogue or collection specified in header: {header}")
 
-    return storage.get_source_catalogue_entity_combinations(
-        catalogue=catalogue, entity=entity, source=header.get("source")
-    )
+    return storage.get_source_catalogue_entity_combinations(catalogue, entity, source=header.get("source"))
 
 
 def apply(msg):

--- a/src/gobupload/compare/event_collector.py
+++ b/src/gobupload/compare/event_collector.py
@@ -9,7 +9,7 @@ from gobcore.model.metadata import FIELD
 
 class EventCollector:
 
-    MAX_BULK = 100_000          # Max number of events of same type in one bulk event
+    MAX_BULK = 50_000           # Max number of events of same type in one bulk event
     BULK_TYPES = ["CONFIRM"]    # Only CONFIRM events are grouped in bulk events
 
     def __init__(self, contents_writer, confirms_writer, version):

--- a/src/gobupload/compare/event_collector.py
+++ b/src/gobupload/compare/event_collector.py
@@ -9,7 +9,7 @@ from gobcore.model.metadata import FIELD
 
 class EventCollector:
 
-    MAX_BULK = 50_000           # Max number of events of same type in one bulk event
+    MAX_BULK = 10_000           # Max number of events of same type in one bulk event
     BULK_TYPES = ["CONFIRM"]    # Only CONFIRM events are grouped in bulk events
 
     def __init__(self, contents_writer, confirms_writer, version):

--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -572,7 +572,8 @@ WHERE
         :return: a dict of ids with last_event for the collection
         """
         query = select(self.DbEntity._tid, self.DbEntity._last_event)
-        return {row[0]: row[1] for row in self.session.execute(query).all()}
+        exc_opts = {"execution_options": {"yield_per": 25_000}}
+        return {row[0]: row[1] for row in self.session.stream_execute(query, **exc_opts)}
 
     def get_column_values_for_key_value(self, column: str, key: str, value: Any) -> Sequence[Row]:
         """Gets the distinct values for column within the given source for the given key-value

--- a/src/gobupload/utils.py
+++ b/src/gobupload/utils.py
@@ -23,10 +23,9 @@ def get_event_ids(storage):
     :param storage: GOB (events + entities)
     :return:highest entity eventid and last eventid
     """
-    with storage.get_session():
-        entity_max_eventid = storage.get_entity_max_eventid()
-        last_eventid = storage.get_last_eventid()
-        return entity_max_eventid, last_eventid
+    entity_max_eventid = storage.get_entity_max_eventid()
+    last_eventid = storage.get_last_eventid()
+    return entity_max_eventid, last_eventid
 
 
 def random_string(length):

--- a/src/tests/apply/test_apply.py
+++ b/src/tests/apply/test_apply.py
@@ -90,7 +90,7 @@ class TestApply(TestCase):
         result = apply(msg)
 
         self.mock_storage.get_source_catalogue_entity_combinations.assert_called_with(
-            catalogue="any cat", entity="any ent", source="any src"
+            "any cat", "any ent", source="any src"
         )
 
         result_msg = {'header': msg["header"], 'summary': ANY}
@@ -100,18 +100,6 @@ class TestApply(TestCase):
 
         mock_event_notification.assert_called_with({}, [1, 1])
         mock_add_notification.assert_called_with(result_msg, mock_event_notification())
-
-        # collection instead of entity
-        apply({"header": {"catalogue": "any cat", "collection": "any ent", "source": "any src"}})
-        self.mock_storage.get_source_catalogue_entity_combinations.assert_called_with(
-            catalogue="any cat", entity="any ent", source="any src"
-        )
-
-        # only catalogue
-        apply({"header": {"catalogue": "any cat"}})
-        self.mock_storage.get_source_catalogue_entity_combinations.assert_called_with(
-            catalogue="any cat", entity=None, source=None
-        )
 
         # empty header raises
         with self.assertRaises(GOBException):


### PR DESCRIPTION
- Replace DISTINCT call to events table with result from pg_tables
- Reduce usage of server side cursor, should not be necessary
- Use datetime parameter in apply_confirms query
- lower max bulk_confirm to 10.000