### PR TITLE
Only update date_confirmed if necessary

### DIFF
--- a/src/gobupload/storage/handler.py
+++ b/src/gobupload/storage/handler.py
@@ -719,14 +719,19 @@ WHERE
         :param timestamp: Time to set as last_confirmed
         :return:
         """
+        timestamp_dt = datetime.datetime.fromisoformat(timestamp)
+        col_confirm = getattr(self.DbEntity, CONFIRM.timestamp_field)
         values_tid = \
             values(column("_tid", String), name="tids") \
             .data([(record["_tid"],) for record in confirms])
 
         stmt = (
             update(self.DbEntity)
-            .where(self.DbEntity._tid == values_tid.c._tid)
-            .values({CONFIRM.timestamp_field: datetime.datetime.fromisoformat(timestamp)})
+            .where(
+                self.DbEntity._tid == values_tid.c._tid,
+                col_confirm != timestamp_dt
+            )
+            .values({col_confirm: timestamp_dt})
             .execution_options(synchronize_session=False)
         )
         self.session.execute(stmt)

--- a/src/tests/storage/test_handler.py
+++ b/src/tests/storage/test_handler.py
@@ -587,11 +587,13 @@ WHERE
             "UPDATE meetbouten_meetbouten "
             "SET _date_confirmed=:_date_confirmed "
             "FROM (VALUES (:param_1), (:param_2)) AS tids (_tid) "
-            "WHERE meetbouten_meetbouten._tid = tids._tid"
+            "WHERE meetbouten_meetbouten._tid = tids._tid AND "
+            "meetbouten_meetbouten._date_confirmed != :date_confirmed_1"
         )
         assert str(compiled) == expected
         assert compiled.params == {
             '_date_confirmed': datetime.datetime(2023, 6, 6, 0, 0),
+            'date_confirmed_1': datetime.datetime(2023, 6, 6, 0, 0),
             'param_1': 'confirm1',
             'param_2': 'confirm2'
         }


### PR DESCRIPTION
Prevents applying confirms if date confirmed is already up-to-date, saving database resources