### PR TITLE
Fix: prevent escaping json values in contents from events

### DIFF
--- a/src/gobupload/update/main.py
+++ b/src/gobupload/update/main.py
@@ -38,8 +38,13 @@ def _store_events(
 
     with (
         ProgressTicker("Store events", chunksize) as progress,
-        storage.get_session(),
-        EventCollector(storage, last_events) as event_collector
+        storage.get_session() as session,
+        EventCollector(storage, last_events) as event_collector,
+
+        # explicitely start transaction context on bind
+        # storage.add_events operates on the bind and not the session
+        # nothing is committed otherwise
+        session.bind.begin()
     ):
         for chunk in ichunked(events, chunksize):
             for event in chunk:


### PR DESCRIPTION
events.contents looks like this now:
```json
"{\"modifications\": [{\"key\": \"gebruiksdoel\", \"old_value\": [{\"code\": 5, \"omschrijving\": \"industriefunctie\"}, {\"code\": 1, \"omschrijving\": \"woonfunctie\"}], \"new_value\": [{\"code\": 1, \"omschrijving\": \"woonfunctie\"}, {\"code\": 5, \"omschrijving\": \"industriefunctie\"}]}, {\"key\": \"_hash\", \"old_value\": \"d9eb845571227ef05b48918c3db23c8e\", \"new_value\": \"f9f1575c7e82f95bf0a1a2ba4a6e650a\"}], \"_hash\": \"f9f1575c7e82f95bf0a1a2ba4a6e650a\", \"_last_event\": 1695819809, \"_tid\": \"0363010000593037.5\"}"
```

Don't implicitely cast values using postgresql `to_json`, instead with `::jsonb` (value is already valid json)

result example:
```json
{"entity": {"_id": "SV00001071_GR01GR.pdf", "_hash": "15606d478a5c0d8905ae12cee21bca90", "_version": "0.1", "_source_id": "SV00001071_GR01GR.pdf", "type_dossier": {"code": "GR", "omschrijving": null}, "documentnummer": "SV00001071_GR01GR.pdf", "bronleverancier": {"code": "SV", "omschrijving": "Stadsdeel Oud-Zuid"}, "registratiedatum": "2008-05-29T14:55:06.000000", "type_brondocument": {"code": "GR", "omschrijving": null}}, "_source_id": "SV00001071_GR01GR.pdf", "_last_event": null, "_entity_source_id": "SV00001071_GR01GR.pdf"}
```

successfully tested with e2e test